### PR TITLE
Add support for local types (fix for #14 and #16)

### DIFF
--- a/src/main/java/net/minecraftforge/srg2source/ast/SymbolRangeEmitter.java
+++ b/src/main/java/net/minecraftforge/srg2source/ast/SymbolRangeEmitter.java
@@ -433,7 +433,7 @@ public class SymbolRangeEmitter
             logFile.println(tab + s);
         }
         if (s.contains("||"))
-            System.exit(1);
+            throw new AssertionError("Empty field found in line: " + s);
     }
 
     public void emitThrowRange(Type exc, ITypeBinding type)

--- a/src/test/java/net/minecraftforge/srg2source/test/SingleTests.java
+++ b/src/test/java/net/minecraftforge/srg2source/test/SingleTests.java
@@ -37,6 +37,19 @@ public class SingleTests
         if (java_version >= 8)
             testClass("Lambda");
     }
+
+    @Test
+    public void testAnonClass() throws IOException
+    {
+        testClass("AnonClass");
+    }
+
+    @Test
+    public void testInnerClass() throws IOException
+    {
+        testClass("InnerClass");
+    }
+
     @Test
     public void testPackageInfo() throws IOException
     {

--- a/src/test/java/net/minecraftforge/srg2source/test/SingleTests.java
+++ b/src/test/java/net/minecraftforge/srg2source/test/SingleTests.java
@@ -51,6 +51,12 @@ public class SingleTests
     }
 
     @Test
+    public void testLocalClass() throws IOException
+    {
+        testClass("LocalClass");
+    }
+
+    @Test
     public void testPackageInfo() throws IOException
     {
         testClass("PackageInfo", "test.package-info");

--- a/src/test/resources/AnonClass.txt
+++ b/src/test/resources/AnonClass.txt
@@ -1,0 +1,26 @@
+public class AnonClass
+{
+    public class Nested
+    {
+        private Object test = new Object()
+        {
+            private String value = "a";
+
+            private String getValue() {
+                return value;
+            }
+        };
+    }
+
+    public static void main(String[] args)
+    {
+        Object test = new Object()
+        {
+            private String value = "b";
+
+            private String getValue() {
+                return value;
+            }
+        };
+    }
+}

--- a/src/test/resources/AnonClass_ret.txt
+++ b/src/test/resources/AnonClass_ret.txt
@@ -1,0 +1,40 @@
+Symbol range map extraction starting
+Processing 1 files
+startProcessing "/AnonClass.java" md5: e36cb4b5ad527aba7e7dc8754a86a095
+Class Start: AnonClass
+   @|/AnonClass.java|13|22|AnonClass|class|AnonClass
+   Class Start: AnonClass.Nested
+      @|/AnonClass.java|42|48|Nested|class|AnonClass.Nested
+      @|/AnonClass.java|71|77|Object|class|java.lang.Object
+      @|/AnonClass.java|71|77|Object|class|java.lang.Object
+      @|/AnonClass.java|78|82|test|field|AnonClass.Nested|test|
+      @|/AnonClass.java|89|95|Object|class|java.lang.Object
+      Anon Class Start: AnonClass.Nested$1
+         @|/AnonClass.java|128|134|String|class|java.lang.String
+         @|/AnonClass.java|135|140|value|field|AnonClass.Nested$1|value|
+         Method Start: getValue()Ljava/lang/String;
+            @|/AnonClass.java|169|175|String|class|java.lang.String
+            @|/AnonClass.java|176|184|getValue|method|AnonClass.Nested$1|getValue|()Ljava/lang/String;
+            @|/AnonClass.java|212|217|value|field|AnonClass.Nested$1|value
+         Method End: getValue()Ljava/lang/String;
+      Anon Class End: AnonClass.Nested$1
+   Class End  : AnonClass.Nested
+   Method Start: main([Ljava/lang/String;)V
+      @|/AnonClass.java|288|292|args|param|AnonClass|main|([Ljava/lang/String;)V|args|0
+      @|/AnonClass.java|274|278|main|method|AnonClass|main|([Ljava/lang/String;)V
+      @|/AnonClass.java|279|285|String|class|java.lang.String
+      @|/AnonClass.java|308|314|Object|class|java.lang.Object
+      @|/AnonClass.java|326|332|Object|class|java.lang.Object
+      Anon Class Start: AnonClass$1
+         @|/AnonClass.java|365|371|String|class|java.lang.String
+         @|/AnonClass.java|372|377|value|field|AnonClass$1|value|
+         Method Start: getValue()Ljava/lang/String;
+            @|/AnonClass.java|406|412|String|class|java.lang.String
+            @|/AnonClass.java|413|421|getValue|method|AnonClass$1|getValue|()Ljava/lang/String;
+            @|/AnonClass.java|449|454|value|field|AnonClass$1|value
+         Method End: getValue()Ljava/lang/String;
+      Anon Class End: AnonClass$1
+   Method End: main([Ljava/lang/String;)V
+Class End  : AnonClass
+endProcessing "/AnonClass.java"
+

--- a/src/test/resources/InnerClass.txt
+++ b/src/test/resources/InnerClass.txt
@@ -1,0 +1,27 @@
+public class InnerClass
+{
+    private static class Inner
+    {
+        private static class Nested
+        {
+            private String value = "a";
+
+            public String getValue()
+            {
+                return value;
+            }
+        }
+
+        private String value = "b";
+
+        public String getValue()
+        {
+            return value;
+        }
+    }
+
+    public static void main(String[] args)
+    {
+        new Inner().getValue();
+    }
+}

--- a/src/test/resources/InnerClass_ret.txt
+++ b/src/test/resources/InnerClass_ret.txt
@@ -1,0 +1,37 @@
+Symbol range map extraction starting
+Processing 1 files
+startProcessing "/InnerClass.java" md5: 2a9eace10eeacad626a7062f74792b31
+Class Start: InnerClass
+   @|/InnerClass.java|13|23|InnerClass|class|InnerClass
+   Class Start: InnerClass.Inner
+      @|/InnerClass.java|51|56|Inner|class|InnerClass.Inner
+      Class Start: InnerClass.Inner.Nested
+         @|/InnerClass.java|92|98|Nested|class|InnerClass.Inner.Nested
+         @|/InnerClass.java|129|135|String|class|java.lang.String
+         @|/InnerClass.java|129|135|String|class|java.lang.String
+         @|/InnerClass.java|136|141|value|field|InnerClass.Inner.Nested|value|
+         Method Start: getValue()Ljava/lang/String;
+            @|/InnerClass.java|169|175|String|class|java.lang.String
+            @|/InnerClass.java|176|184|getValue|method|InnerClass.Inner.Nested|getValue|()Ljava/lang/String;
+            @|/InnerClass.java|224|229|value|field|InnerClass.Inner.Nested|value
+         Method End: getValue()Ljava/lang/String;
+      Class End  : InnerClass.Inner.Nested
+      @|/InnerClass.java|272|278|String|class|java.lang.String
+      @|/InnerClass.java|272|278|String|class|java.lang.String
+      @|/InnerClass.java|279|284|value|field|InnerClass.Inner|value|
+      Method Start: getValue()Ljava/lang/String;
+         @|/InnerClass.java|308|314|String|class|java.lang.String
+         @|/InnerClass.java|315|323|getValue|method|InnerClass.Inner|getValue|()Ljava/lang/String;
+         @|/InnerClass.java|355|360|value|field|InnerClass.Inner|value
+      Method End: getValue()Ljava/lang/String;
+   Class End  : InnerClass.Inner
+   Method Start: main([Ljava/lang/String;)V
+      @|/InnerClass.java|416|420|args|param|InnerClass|main|([Ljava/lang/String;)V|args|0
+      @|/InnerClass.java|402|406|main|method|InnerClass|main|([Ljava/lang/String;)V
+      @|/InnerClass.java|407|413|String|class|java.lang.String
+      @|/InnerClass.java|440|445|Inner|class|InnerClass.Inner
+      @|/InnerClass.java|448|456|getValue|method|InnerClass.Inner|getValue|()Ljava/lang/String;
+   Method End: main([Ljava/lang/String;)V
+Class End  : InnerClass
+endProcessing "/InnerClass.java"
+

--- a/src/test/resources/LocalClass.txt
+++ b/src/test/resources/LocalClass.txt
@@ -1,0 +1,48 @@
+public class LocalClass
+{
+    public class Nested
+    {
+        private void test()
+        {
+            class Local
+            {
+                private String value = "b";
+
+                public String getValue()
+                {
+                    return value;
+                }
+            }
+        }
+    }
+
+    public void funA()
+    {
+        class Local
+        {
+            private String value = "a";
+
+            public String getValue()
+            {
+                return value;
+            }
+        }
+
+        new Local().getValue();
+    }
+
+    public void funB()
+    {
+        class Local
+        {
+            private String value = "a";
+
+            public String getValue()
+            {
+                return value;
+            }
+        }
+
+        new Local().getValue();
+    }
+}

--- a/src/test/resources/LocalClass_ret.txt
+++ b/src/test/resources/LocalClass_ret.txt
@@ -1,0 +1,57 @@
+Symbol range map extraction starting
+Processing 1 files
+startProcessing "/LocalClass.java" md5: 2e417b1052ddf3b672b7094fa3d345f5
+Class Start: LocalClass
+   @|/LocalClass.java|13|23|LocalClass|class|LocalClass
+   Class Start: LocalClass.Nested
+      @|/LocalClass.java|43|49|Nested|class|LocalClass.Nested
+      Method Start: test()V
+         @|/LocalClass.java|77|81|test|method|LocalClass.Nested|test|()V
+         Class Start: LocalClass.Nested$1Local
+            @|/LocalClass.java|112|117|Local|class|
+            @|/LocalClass.java|156|162|String|class|java.lang.String
+            @|/LocalClass.java|156|162|String|class|java.lang.String
+            @|/LocalClass.java|163|168|value|field|LocalClass.Nested$1Local|value|
+            Method Start: getValue()Ljava/lang/String;
+               @|/LocalClass.java|200|206|String|class|java.lang.String
+               @|/LocalClass.java|207|215|getValue|method|LocalClass.Nested$1Local|getValue|()Ljava/lang/String;
+               @|/LocalClass.java|263|268|value|field|LocalClass.Nested$1Local|value
+            Method End: getValue()Ljava/lang/String;
+         Class End  : LocalClass.Nested$1Local
+      Method End: test()V
+   Class End  : LocalClass.Nested
+   Method Start: funA()V
+      @|/LocalClass.java|335|339|funA|method|LocalClass|funA|()V
+      Class Start: LocalClass$1Local
+         @|/LocalClass.java|362|367|Local|class|
+         @|/LocalClass.java|398|404|String|class|java.lang.String
+         @|/LocalClass.java|398|404|String|class|java.lang.String
+         @|/LocalClass.java|405|410|value|field|LocalClass$1Local|value|
+         Method Start: getValue()Ljava/lang/String;
+            @|/LocalClass.java|438|444|String|class|java.lang.String
+            @|/LocalClass.java|445|453|getValue|method|LocalClass$1Local|getValue|()Ljava/lang/String;
+            @|/LocalClass.java|493|498|value|field|LocalClass$1Local|value
+         Method End: getValue()Ljava/lang/String;
+      Class End  : LocalClass$1Local
+      @|/LocalClass.java|537|542|Local|class|
+      @|/LocalClass.java|545|553|getValue|method|LocalClass|getValue|()Ljava/lang/String;
+   Method End: funA()V
+   Method Start: funB()V
+      @|/LocalClass.java|580|584|funB|method|LocalClass|funB|()V
+      Class Start: LocalClass$2Local
+         @|/LocalClass.java|607|612|Local|class|
+         @|/LocalClass.java|643|649|String|class|java.lang.String
+         @|/LocalClass.java|643|649|String|class|java.lang.String
+         @|/LocalClass.java|650|655|value|field|LocalClass$2Local|value|
+         Method Start: getValue()Ljava/lang/String;
+            @|/LocalClass.java|683|689|String|class|java.lang.String
+            @|/LocalClass.java|690|698|getValue|method|LocalClass$2Local|getValue|()Ljava/lang/String;
+            @|/LocalClass.java|738|743|value|field|LocalClass$2Local|value
+         Method End: getValue()Ljava/lang/String;
+      Class End  : LocalClass$2Local
+      @|/LocalClass.java|782|787|Local|class|
+      @|/LocalClass.java|790|798|getValue|method|LocalClass|getValue|()Ljava/lang/String;
+   Method End: funB()V
+Class End  : LocalClass
+endProcessing "/LocalClass.java"
+


### PR DESCRIPTION
Without this change declaration of local class triggers call to `System.exit(1)`. This PR:
- replaces `System.exit(1)` call with error throw, to simplify debugging (AssertionError is used, since there is no point in catching this)
- fixes generation of local type name (since they don't have qualified names). This is bit of guesswork based on anonymous class names, since I can't find any example of such names in SRG files. Which is also good thing, because it will not break any existing builds (verified by running `MinecraftTest`). Nested classes inside local types are not considered (though they look like `pkg.Outer$1Local.Inner`). **Maintaners:** Are there any rules for naming such cases in SRG files?

Pushing as three commits to make review/commenting easier, will squash if accepted.