### PR TITLE
Remove unused dependency on Spoon to prevent conflicts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,8 @@ dependencies {
     
     compile 'org.eclipse.jdt:org.eclipse.jdt.core:3.12.0.v20160315-2126'
     
-    // Potential Eclipse AST replacement
-    compile 'fr.inria.gforge.spoon:spoon-core:5.1.0'
+    // Potential Eclipse AST replacement (not used yet)
+    //compile 'fr.inria.gforge.spoon:spoon-core:5.1.0'
     
     // maven deployer jar
     deployerJars "org.apache.maven.wagon:wagon-ssh:2.2"


### PR DESCRIPTION
Currently, Srg2Source depends on Spoon as a "potential Eclipse AST replacement" but it is not actually used yet. This is not a problem correctly, however Srg2Source is shaded into ForgeGradle, and consequently the entirely unused Spoon library is also shaded. 

As soon as other Gradle plugins attempt to depend on a newer version of Spoon, they will easily run into problems because the old version in ForgeGradle will conflict with the newer version.

This is very similar to #11 that broke due to the jgit dependency.