### PR TITLE
Processing issue causing permanent hang.

### DIFF
--- a/src/main/java/net/minecraftforge/srg2source/rangeapplier/RangeApplier.java
+++ b/src/main/java/net/minecraftforge/srg2source/rangeapplier/RangeApplier.java
@@ -420,7 +420,7 @@ public class RangeApplier extends ConfLogger<RangeApplier>
         int packageLine = -1;
 
         String line;
-        while (nextIndex > -1)
+        outer: while (nextIndex > -1)
         {
             line = data.substring(lastIndex, nextIndex);
 
@@ -429,7 +429,7 @@ public class RangeApplier extends ConfLogger<RangeApplier>
                 lastIndex++;
                 nextIndex = data.indexOf("\n", lastIndex + 1);
                 if (nextIndex == -1) //EOF
-                    break;
+                    break outer;
                 line = data.substring(lastIndex, nextIndex);
             }
             //log("Line: " + line);


### PR DESCRIPTION
This minimal change will fix the issue where a file with no (apparent) imports, and three \n's at the end of the file will cause an infinite loop in updateImports.  For the loop to operate properly, at least one line must start with "import ". If no such line is found, the break at line 432 was intended to exit the loop, but the code at line 516 will always convert a value of -1 to another value (assuming the file has at least one \n), which will prevent the outer loops exit criteria from being met.  **This is a bandaid, and not a real fix.  This file will need a full refactor/rewrite to correctly handle unusual situations.**  I will begin work on a real fix, but I don't have a timeline on that.

To observe the error, remove the changes in the commit, add whitespace in front of all import statements in whitespace.txt, and comment out the following line in SingleTests.java
Assert.assertEquals(Files.toString(new File(getClass().getResource("/" + resource + "_ret.txt").getFile()), Charsets.UTF_8), bos.toString().replaceAll("\r?\n", "\n").replaceAll("Cache Hit!\n", ""));

after that procedure has been followed, the unit test will hang forever when it tries to process whitespace.txt.

This only occurs if the processing sees no imports at all, due either to a lack of imports, or valid java syntax that the parser is unable to handle.  If even a single import is successfully processed, the routine will properly exit the outer loop at line 512.  Both the original code, and this bandaid, can result in a successful execution producing an incorrect sources.jar