### PR TITLE
Throw AssertionErrors instead of using System.exit(1) to help debugging

### DIFF
--- a/src/main/java/net/minecraftforge/srg2source/ast/CodeFixer.java
+++ b/src/main/java/net/minecraftforge/srg2source/ast/CodeFixer.java
@@ -155,7 +155,7 @@ public class CodeFixer
                 if (data == null)
                 {
                     log("    Could not find sourcekey for fixes: " + key);
-                    System.exit(1);
+                    throw new AssertionError("Could not find sourcekey for fixes: " + key);
                 }
 
                 int offset = 0;
@@ -275,7 +275,7 @@ public class CodeFixer
                         {
                             log("      Could not find class: " + clsName);
                             log("      " + p.toString());
-                            if (FATAL) System.exit(1); else continue;
+                            if (FATAL) throw new AssertionError("Could not find class: " + clsName + "\n" + p); else continue;
                         }
                         else
                         {
@@ -295,7 +295,7 @@ public class CodeFixer
                         if (cls == null)
                         {
                             log("      Could not find class for field " + p.toString());
-                            if (FATAL) System.exit(1); else continue;
+                            if (FATAL) throw new AssertionError("Could not find class for field " + p); else continue;
                         }
                         boolean exit = false;
                         for (FieldDeclaration field : cls.getFields())
@@ -361,7 +361,7 @@ public class CodeFixer
                         if (icls == null)
                         {
                             log("      Could not find class in SRG " + impl);
-                            if (FATAL) System.exit(1); else continue;
+                            if (FATAL) throw new AssertionError("Could not find class in SRG " + impl); else continue;
                         }
 
                         SrgFile.Node mtd = icls.methods1.get(name + signature);
@@ -371,7 +371,7 @@ public class CodeFixer
                         if (treeNode == null)
                         {
                             log("    Could not find missing method, and parent was null: " + impl + "." + name + signature);
-                            if (FATAL) System.exit(1); else continue;
+                            if (FATAL) throw new AssertionError("Could not find missing method, and parent was null: " + impl + "." + name + signature); else continue;
                         }
 
                         while(mtd == null && treeNode != null)
@@ -392,7 +392,7 @@ public class CodeFixer
                             if (!FIXES.containsKey(key))
                             {
                                 log("      Could not find bounce rename " + key);
-                                if (FATAL) System.exit(1); else continue;
+                                if (FATAL) throw new AssertionError("Could not find bounce rename " + key); else continue;
                             }
                             else
                             {
@@ -477,7 +477,7 @@ public class CodeFixer
             if (cls == null)
             {
                 System.out.println("WTF! COULD NOT FIND DUPLICATE CLASS");
-                System.exit(1);
+                throw new AssertionError("WTF! COULD NOT FIND DUPLICATE CLASS");
             }
 
             for (MethodDeclaration mtd : cls.getMethods())

--- a/src/main/java/net/minecraftforge/srg2source/ast/SymbolRangeEmitter.java
+++ b/src/main/java/net/minecraftforge/srg2source/ast/SymbolRangeEmitter.java
@@ -433,7 +433,7 @@ public class SymbolRangeEmitter
             logFile.println(tab + s);
         }
         if (s.contains("||"))
-            System.exit(1);
+            throw new AssertionError("Empty field found in line: " + s);
     }
 
     public void emitThrowRange(Type exc, ITypeBinding type)


### PR DESCRIPTION
Currently, the `System.exit(1)` calls will kill the gradle daemon during a gradle build, and it's difficult to determine that the crash came from S2S.
Tracking issues down to S2S will hopefully be easier if it throws an exception with a stack trace instead of just exiting.