### PR TITLE
Fix package declaration mapping & add Java Version option

### DIFF
--- a/src/main/java/net/minecraftforge/srg2source/ast/RangeExtractor.java
+++ b/src/main/java/net/minecraftforge/srg2source/ast/RangeExtractor.java
@@ -62,15 +62,16 @@ public class RangeExtractor extends ConfLogger<RangeExtractor>
 
     public static void main(String[] args) throws IOException
     {
-        if (args.length != 3)
+        if (args.length < 3)
         {
-            System.out.println("Usage: RangeExtract [SourceDir] [LibDir] [OutFile]");
+            System.out.println("Usage: RangeExtract <SourceDir> <LibDir> <OutFile> [JavaVersion]");
             return;
         }
 
         File src = new File(args[0]);
 
-        RangeExtractor extractor = new RangeExtractor();
+        String javaVersion = args.length > 3 ? args[3] : JAVA_1_6;
+        RangeExtractor extractor = new RangeExtractor(javaVersion);
         extractor.setSrcRoot(new File(args[0]));
 
         if (args[1].equals("none") || args[1].isEmpty())

--- a/src/main/java/net/minecraftforge/srg2source/rangeapplier/RangeApplier.java
+++ b/src/main/java/net/minecraftforge/srg2source/rangeapplier/RangeApplier.java
@@ -370,6 +370,11 @@ public class RangeApplier extends ConfLogger<RangeApplier>
                     }
                 }
             }
+            else if (info.key.startsWith("package ") && newTopLevelClassPackage != null)
+            {
+                // replace the package declaration in this file with the new package
+                newName = newTopLevelClassPackage.replace('/', '.');
+            }
 
             if (oldName.equals(newName))
                 continue; //No rename? Skip the rest.

--- a/src/test/java/net/minecraftforge/srg2source/test/SingleTests.java
+++ b/src/test/java/net/minecraftforge/srg2source/test/SingleTests.java
@@ -52,6 +52,12 @@ public class SingleTests
     }
 
     @Test
+    public void testPackagedClass() throws IOException
+    {
+        testClass("obfuscated/PackagedClass");
+    }
+
+    @Test
     public void testPackageInfo() throws IOException
     {
         testClass("PackageInfo", "test.package-info");
@@ -126,8 +132,8 @@ public class SingleTests
         applier.setOutLogger(new PrintStream(bos));
 
         applier.remapSources(new SimpleInputSupplier(resource, clsName), out, map, true);
-        Assert.assertEquals(getFileContents(resource, "_maped.txt"), out.get(0));
-        Assert.assertEquals(getFileContents(resource, "_maped_ret.txt"), bos.toString().replaceAll("\r?\n", "\n"));
+        Assert.assertEquals(getFileContents(resource, "_mapped.txt"), out.get(0));
+        Assert.assertEquals(getFileContents(resource, "_mapped_ret.txt"), bos.toString().replaceAll("\r?\n", "\n"));
     }
 
     private String getFileContents(String resource, String suffix) throws IOException {

--- a/src/test/resources/AnonClass_ret.txt
+++ b/src/test/resources/AnonClass_ret.txt
@@ -2,18 +2,18 @@ Symbol range map extraction starting
 Processing 1 files
 startProcessing "/AnonClass.java" md5: e36cb4b5ad527aba7e7dc8754a86a095
 Class Start: AnonClass
-   @|/AnonClass.java|13|22|AnonClass|class|AnonClass
+   @|/AnonClass.java|13|22|AnonClass|class|AnonClass|false
    Class Start: AnonClass.Nested
-      @|/AnonClass.java|42|48|Nested|class|AnonClass.Nested
-      @|/AnonClass.java|71|77|Object|class|java.lang.Object
-      @|/AnonClass.java|71|77|Object|class|java.lang.Object
+      @|/AnonClass.java|42|48|Nested|class|AnonClass.Nested|false
+      @|/AnonClass.java|71|77|Object|class|java.lang.Object|false
+      @|/AnonClass.java|71|77|Object|class|java.lang.Object|false
       @|/AnonClass.java|78|82|test|field|AnonClass.Nested|test|
-      @|/AnonClass.java|89|95|Object|class|java.lang.Object
+      @|/AnonClass.java|89|95|Object|class|java.lang.Object|false
       Anon Class Start: AnonClass.Nested$1
-         @|/AnonClass.java|128|134|String|class|java.lang.String
+         @|/AnonClass.java|128|134|String|class|java.lang.String|false
          @|/AnonClass.java|135|140|value|field|AnonClass.Nested$1|value|
          Method Start: getValue()Ljava/lang/String;
-            @|/AnonClass.java|169|175|String|class|java.lang.String
+            @|/AnonClass.java|169|175|String|class|java.lang.String|false
             @|/AnonClass.java|176|184|getValue|method|AnonClass.Nested$1|getValue|()Ljava/lang/String;
             @|/AnonClass.java|212|217|value|field|AnonClass.Nested$1|value
          Method End: getValue()Ljava/lang/String;
@@ -22,14 +22,14 @@ Class Start: AnonClass
    Method Start: main([Ljava/lang/String;)V
       @|/AnonClass.java|288|292|args|param|AnonClass|main|([Ljava/lang/String;)V|args|0
       @|/AnonClass.java|274|278|main|method|AnonClass|main|([Ljava/lang/String;)V
-      @|/AnonClass.java|279|285|String|class|java.lang.String
-      @|/AnonClass.java|308|314|Object|class|java.lang.Object
-      @|/AnonClass.java|326|332|Object|class|java.lang.Object
+      @|/AnonClass.java|279|285|String|class|java.lang.String|false
+      @|/AnonClass.java|308|314|Object|class|java.lang.Object|false
+      @|/AnonClass.java|326|332|Object|class|java.lang.Object|false
       Anon Class Start: AnonClass$1
-         @|/AnonClass.java|365|371|String|class|java.lang.String
+         @|/AnonClass.java|365|371|String|class|java.lang.String|false
          @|/AnonClass.java|372|377|value|field|AnonClass$1|value|
          Method Start: getValue()Ljava/lang/String;
-            @|/AnonClass.java|406|412|String|class|java.lang.String
+            @|/AnonClass.java|406|412|String|class|java.lang.String|false
             @|/AnonClass.java|413|421|getValue|method|AnonClass$1|getValue|()Ljava/lang/String;
             @|/AnonClass.java|449|454|value|field|AnonClass$1|value
          Method End: getValue()Ljava/lang/String;

--- a/src/test/resources/GenericClasses_ret.txt
+++ b/src/test/resources/GenericClasses_ret.txt
@@ -2,9 +2,9 @@ Symbol range map extraction starting
 Processing 1 files
 startProcessing "/GenericClasses.java" md5: 9fd0334849c82de8a64a31ed3b656b37
 Class Start: GenericClasses
-   @|/GenericClasses.java|81|95|GenericClasses|class|GenericClasses
+   @|/GenericClasses.java|81|95|GenericClasses|class|GenericClasses|false
    Class Start: GenericClasses.IFoo
-      @|/GenericClasses.java|127|131|IFoo|class|GenericClasses.IFoo
+      @|/GenericClasses.java|127|131|IFoo|class|GenericClasses.IFoo|false
       Method Start: bar(Ljava/lang/Object;)Ljava/lang/Object;
          @|/GenericClasses.java|157|160|arg|param|GenericClasses.IFoo|bar|(Ljava/lang/Object;)Ljava/lang/Object;|arg|0
          @|/GenericClasses.java|151|154|bar|method|GenericClasses.IFoo|bar|(Ljava/lang/Object;)Ljava/lang/Object;
@@ -12,27 +12,27 @@ Class Start: GenericClasses
    Class End  : GenericClasses.IFoo
    Method Start: func(Ljava/util/Collection;)Ljava/util/concurrent/Callable;
       @|/GenericClasses.java|227|230|par|param|GenericClasses|func|(Ljava/util/Collection;)Ljava/util/concurrent/Callable;|par|0
-      @|/GenericClasses.java|193|201|Callable|class|java.util.concurrent.Callable
+      @|/GenericClasses.java|193|201|Callable|class|java.util.concurrent.Callable|false
       @|/GenericClasses.java|208|212|func|method|GenericClasses|func|(Ljava/util/Collection;)Ljava/util/concurrent/Callable;
-      @|/GenericClasses.java|213|223|Collection|class|java.util.Collection
+      @|/GenericClasses.java|213|223|Collection|class|java.util.Collection|false
       @|/GenericClasses.java|244|247|par|param|GenericClasses|func|(Ljava/util/Collection;)Ljava/util/concurrent/Callable;|par|0
    Method End: func(Ljava/util/Collection;)Ljava/util/concurrent/Callable;
    Method Start: main()V
       @|/GenericClasses.java|288|292|main|method|GenericClasses|main|()V
-      @|/GenericClasses.java|309|313|IFoo|class|GenericClasses.IFoo
-      @|/GenericClasses.java|314|320|String|class|java.lang.String
-      @|/GenericClasses.java|333|337|IFoo|class|GenericClasses.IFoo
-      @|/GenericClasses.java|338|344|String|class|java.lang.String
+      @|/GenericClasses.java|309|313|IFoo|class|GenericClasses.IFoo|false
+      @|/GenericClasses.java|314|320|String|class|java.lang.String|false
+      @|/GenericClasses.java|333|337|IFoo|class|GenericClasses.IFoo|false
+      @|/GenericClasses.java|338|344|String|class|java.lang.String|false
       Anon Class Start: GenericClasses$1
          Method Start: bar(Ljava/lang/String;)Ljava/lang/String;
             @|/GenericClasses.java|395|398|arg|param|GenericClasses$1|bar|(Ljava/lang/String;)Ljava/lang/String;|arg|0
-            @|/GenericClasses.java|377|383|String|class|java.lang.String
+            @|/GenericClasses.java|377|383|String|class|java.lang.String|false
             @|/GenericClasses.java|384|387|bar|method|GenericClasses.IFoo|bar|(Ljava/lang/Object;)Ljava/lang/Object;
-            @|/GenericClasses.java|388|394|String|class|java.lang.String
+            @|/GenericClasses.java|388|394|String|class|java.lang.String|false
          Method End: bar(Ljava/lang/String;)Ljava/lang/String;
       Anon Class End: GenericClasses$1
       @|/GenericClasses.java|481|484|bar|method|GenericClasses.IFoo|bar|(Ljava/lang/Object;)Ljava/lang/Object;
-      @|/GenericClasses.java|502|506|IFoo|class|GenericClasses.IFoo
+      @|/GenericClasses.java|502|506|IFoo|class|GenericClasses.IFoo|false
       @|/GenericClasses.java|513|516|bar|method|GenericClasses.IFoo|bar|(Ljava/lang/Object;)Ljava/lang/Object;
    Method End: main()V
 Class End  : GenericClasses

--- a/src/test/resources/InnerClass_ret.txt
+++ b/src/test/resources/InnerClass_ret.txt
@@ -2,25 +2,25 @@ Symbol range map extraction starting
 Processing 1 files
 startProcessing "/InnerClass.java" md5: 2a9eace10eeacad626a7062f74792b31
 Class Start: InnerClass
-   @|/InnerClass.java|13|23|InnerClass|class|InnerClass
+   @|/InnerClass.java|13|23|InnerClass|class|InnerClass|false
    Class Start: InnerClass.Inner
-      @|/InnerClass.java|51|56|Inner|class|InnerClass.Inner
+      @|/InnerClass.java|51|56|Inner|class|InnerClass.Inner|false
       Class Start: InnerClass.Inner.Nested
-         @|/InnerClass.java|92|98|Nested|class|InnerClass.Inner.Nested
-         @|/InnerClass.java|129|135|String|class|java.lang.String
-         @|/InnerClass.java|129|135|String|class|java.lang.String
+         @|/InnerClass.java|92|98|Nested|class|InnerClass.Inner.Nested|false
+         @|/InnerClass.java|129|135|String|class|java.lang.String|false
+         @|/InnerClass.java|129|135|String|class|java.lang.String|false
          @|/InnerClass.java|136|141|value|field|InnerClass.Inner.Nested|value|
          Method Start: getValue()Ljava/lang/String;
-            @|/InnerClass.java|169|175|String|class|java.lang.String
+            @|/InnerClass.java|169|175|String|class|java.lang.String|false
             @|/InnerClass.java|176|184|getValue|method|InnerClass.Inner.Nested|getValue|()Ljava/lang/String;
             @|/InnerClass.java|224|229|value|field|InnerClass.Inner.Nested|value
          Method End: getValue()Ljava/lang/String;
       Class End  : InnerClass.Inner.Nested
-      @|/InnerClass.java|272|278|String|class|java.lang.String
-      @|/InnerClass.java|272|278|String|class|java.lang.String
+      @|/InnerClass.java|272|278|String|class|java.lang.String|false
+      @|/InnerClass.java|272|278|String|class|java.lang.String|false
       @|/InnerClass.java|279|284|value|field|InnerClass.Inner|value|
       Method Start: getValue()Ljava/lang/String;
-         @|/InnerClass.java|308|314|String|class|java.lang.String
+         @|/InnerClass.java|308|314|String|class|java.lang.String|false
          @|/InnerClass.java|315|323|getValue|method|InnerClass.Inner|getValue|()Ljava/lang/String;
          @|/InnerClass.java|355|360|value|field|InnerClass.Inner|value
       Method End: getValue()Ljava/lang/String;
@@ -28,8 +28,8 @@ Class Start: InnerClass
    Method Start: main([Ljava/lang/String;)V
       @|/InnerClass.java|416|420|args|param|InnerClass|main|([Ljava/lang/String;)V|args|0
       @|/InnerClass.java|402|406|main|method|InnerClass|main|([Ljava/lang/String;)V
-      @|/InnerClass.java|407|413|String|class|java.lang.String
-      @|/InnerClass.java|440|445|Inner|class|InnerClass.Inner
+      @|/InnerClass.java|407|413|String|class|java.lang.String|false
+      @|/InnerClass.java|440|445|Inner|class|InnerClass.Inner|false
       @|/InnerClass.java|448|456|getValue|method|InnerClass.Inner|getValue|()Ljava/lang/String;
    Method End: main([Ljava/lang/String;)V
 Class End  : InnerClass

--- a/src/test/resources/Lambda_ret.txt
+++ b/src/test/resources/Lambda_ret.txt
@@ -2,12 +2,12 @@ Symbol range map extraction starting
 Processing 1 files
 startProcessing "/Lambda.java" md5: 4c05901959835b10dc5618de02e3cd87
 Class Start: Lambda
-   @|/Lambda.java|13|19|Lambda|class|Lambda
-   @|/Lambda.java|40|48|Runnable|class|java.lang.Runnable
-   @|/Lambda.java|40|48|Runnable|class|java.lang.Runnable
+   @|/Lambda.java|13|19|Lambda|class|Lambda|false
+   @|/Lambda.java|40|48|Runnable|class|java.lang.Runnable|false
+   @|/Lambda.java|40|48|Runnable|class|java.lang.Runnable|false
    @|/Lambda.java|49|59|workerTask|field|Lambda|workerTask|
-   @|/Lambda.java|159|164|Error|class|java.lang.Error
-   @|/Lambda.java|301|310|Throwable|class|java.lang.Throwable
+   @|/Lambda.java|159|164|Error|class|java.lang.Error|false
+   @|/Lambda.java|301|310|Throwable|class|java.lang.Throwable|false
 Class End  : Lambda
 endProcessing "/Lambda.java"
 

--- a/src/test/resources/PackageInfo_ret.txt
+++ b/src/test/resources/PackageInfo_ret.txt
@@ -2,7 +2,7 @@ Symbol range map extraction starting
 Processing 1 files
 startProcessing "/test/package-info.java" md5: c33c9d94791783d0fe61f3f7034f22b5
 @|/test/package-info.java|40|58|net.minecraft.core|package|net.minecraft.core|(file)
-@|/test/package-info.java|1|11|Deprecated|class|java.lang.Deprecated
-@|/test/package-info.java|13|22|Generated|class|javax.annotation.Generated
+@|/test/package-info.java|1|11|Deprecated|class|java.lang.Deprecated|false
+@|/test/package-info.java|13|22|Generated|class|javax.annotation.Generated|false
 endProcessing "/test/package-info.java"
 

--- a/src/test/resources/Whitespace_mapped.txt
+++ b/src/test/resources/Whitespace_mapped.txt
@@ -1,6 +1,6 @@
 @Deprecated/* was Deprecated*/
 @Generated/* was Generated*/("TEST!")
-package core;
+package not_core;
 
 import moved.Deprecated;
 import moved.Generated;

--- a/src/test/resources/Whitespace_mapped_ret.txt
+++ b/src/test/resources/Whitespace_mapped_ret.txt
@@ -2,6 +2,7 @@ Processing 1 files
 Start Processing: /core/package-info.java
 Rename class java/lang/Deprecated[1,11]::Deprecated->Deprecated/* was Deprecated*/
 Rename class javax/annotation/Generated[32,41]::Generated->Generated/* was Generated*/
+Rename package core/package-info[77,81]::core->not_core
 Import: moved.Deprecated
 Import: moved.Generated
 Rename file /core/package-info.java -> not_core/package-info.java

--- a/src/test/resources/Whitespace_ret.txt
+++ b/src/test/resources/Whitespace_ret.txt
@@ -2,7 +2,7 @@ Symbol range map extraction starting
 Processing 1 files
 startProcessing "/core/package-info.java" md5: 7962bd9a7bb5458ad34e346b2328c280
 @|/core/package-info.java|40|44|core|package|core|(file)
-@|/core/package-info.java|1|11|Deprecated|class|java.lang.Deprecated
-@|/core/package-info.java|13|22|Generated|class|javax.annotation.Generated
+@|/core/package-info.java|1|11|Deprecated|class|java.lang.Deprecated|false
+@|/core/package-info.java|13|22|Generated|class|javax.annotation.Generated|false
 endProcessing "/core/package-info.java"
 

--- a/src/test/resources/obfuscated/PackagedClass.txt
+++ b/src/test/resources/obfuscated/PackagedClass.txt
@@ -1,0 +1,7 @@
+package obfuscated;
+
+public class PackagedClass {
+    public static void main(String[] args) {
+        System.out.println("Man phase is so cool");
+    }
+}

--- a/src/test/resources/obfuscated/PackagedClass_mapped.txt
+++ b/src/test/resources/obfuscated/PackagedClass_mapped.txt
@@ -1,0 +1,7 @@
+package deobfuscated;
+
+public class PackagedClass/* was PackagedClass*/ {
+    public static void main(String[] args) {
+        System.out.println("Man phase is so cool");
+    }
+}

--- a/src/test/resources/obfuscated/PackagedClass_mapped_ret.txt
+++ b/src/test/resources/obfuscated/PackagedClass_mapped_ret.txt
@@ -1,0 +1,7 @@
+Processing 1 files
+Start Processing: /obfuscated/PackagedClass.java
+Rename package obfuscated/PackagedClass[8,18]::obfuscated->deobfuscated
+Rename class obfuscated/PackagedClass[36,49]::PackagedClass->PackagedClass/* was PackagedClass*/
+Rename file /obfuscated/PackagedClass.java -> deobfuscated/PackagedClass.java
+End  Processing: deobfuscated/PackagedClass.java
+

--- a/src/test/resources/obfuscated/PackagedClass_ret.txt
+++ b/src/test/resources/obfuscated/PackagedClass_ret.txt
@@ -1,0 +1,17 @@
+Symbol range map extraction starting
+Processing 1 files
+startProcessing "/obfuscated/PackagedClass.java" md5: 8e7460457359e4014941ddfb677ceeed
+@|/obfuscated/PackagedClass.java|8|18|obfuscated|package|obfuscated|(file)
+Class Start: obfuscated.PackagedClass
+   @|/obfuscated/PackagedClass.java|34|47|PackagedClass|class|obfuscated.PackagedClass|false
+   Method Start: main([Ljava/lang/String;)V
+      @|/obfuscated/PackagedClass.java|87|91|args|param|obfuscated.PackagedClass|main|([Ljava/lang/String;)V|args|0
+      @|/obfuscated/PackagedClass.java|73|77|main|method|obfuscated.PackagedClass|main|([Ljava/lang/String;)V
+      @|/obfuscated/PackagedClass.java|78|84|String|class|java.lang.String|false
+      @|/obfuscated/PackagedClass.java|103|109|System|class|java.lang.System|false
+      @|/obfuscated/PackagedClass.java|110|113|out|field|java.lang.System|out
+      @|/obfuscated/PackagedClass.java|114|121|println|method|java.io.PrintStream|println|(Ljava/lang/String;)V
+   Method End: main([Ljava/lang/String;)V
+Class End  : obfuscated.PackagedClass
+endProcessing "/obfuscated/PackagedClass.java"
+

--- a/src/test/resources/obfuscated/PackagedClass_srg.txt
+++ b/src/test/resources/obfuscated/PackagedClass_srg.txt
@@ -1,0 +1,1 @@
+CL: obfuscated/PackagedClass deobfuscated/PackagedClass


### PR DESCRIPTION
Files were being moved to the correct directory but the package
declarations at the top weren't changing. This will assume all package
declarations in a file should be changed to the new package we're
mapping to.

I also added a Java Version option to the Extractor because the Spigot
codebase uses Java 8. It defaults to Java 6.