### PR TITLE
Fix some class references not being marked as qualified

### DIFF
--- a/src/main/java/net/minecraftforge/srg2source/ast/SymbolRangeEmitter.java
+++ b/src/main/java/net/minecraftforge/srg2source/ast/SymbolRangeEmitter.java
@@ -96,11 +96,12 @@ public class SymbolRangeEmitter
         if (type.isParameterizedType())
         {
             ParameterizedType p = (ParameterizedType)type;
+            emitTypeRange(p.getType(), qualified);
             for (Type t : (List<Type>)p.typeArguments())
             {
                 emitTypeRange(t);
             }
-            type = p.getType();
+            return;
         }
 
         if (type.isWildcardType())

--- a/src/main/java/net/minecraftforge/srg2source/ast/SymbolRangeEmitter.java
+++ b/src/main/java/net/minecraftforge/srg2source/ast/SymbolRangeEmitter.java
@@ -70,7 +70,11 @@ public class SymbolRangeEmitter
      * Emit type reference element range (This is for when types are used, not
      * declared) Only class name references will be emitted
      */
-    public void emitTypeRange(Type type)
+    public void emitTypeRange(Type type) {
+        emitTypeRange(type, false);
+    }
+
+    public void emitTypeRange(Type type, boolean qualified)
     {
         if (type == null)
         {
@@ -118,7 +122,7 @@ public class SymbolRangeEmitter
         else if (type.isSimpleType())
         {
             SimpleType stype = (SimpleType)type;
-            emitReferencedClass(stype.getName(), stype.getName().resolveTypeBinding(), false);
+            emitReferencedClass(stype.getName(), stype.getName().resolveTypeBinding(), qualified);
         }
         else
         {

--- a/src/main/java/net/minecraftforge/srg2source/ast/SymbolReferenceWalker.java
+++ b/src/main/java/net/minecraftforge/srg2source/ast/SymbolReferenceWalker.java
@@ -225,8 +225,6 @@ public class SymbolReferenceWalker extends ASTVisitor
     }
 
     public boolean visit(FieldDeclaration node) {
-        emitter.emitTypeRange(node.getType()); //TODO: This double prints due to the walk below, Why are we specifically handling fields?
-
         this.walk(node.getJavadoc());
 
         if (node.getAST().apiLevel() >= 3)

--- a/src/test/resources/AnonClass_ret.txt
+++ b/src/test/resources/AnonClass_ret.txt
@@ -6,7 +6,6 @@ Class Start: AnonClass
    Class Start: AnonClass.Nested
       @|/AnonClass.java|42|48|Nested|class|AnonClass.Nested|false
       @|/AnonClass.java|71|77|Object|class|java.lang.Object|false
-      @|/AnonClass.java|71|77|Object|class|java.lang.Object|false
       @|/AnonClass.java|78|82|test|field|AnonClass.Nested|test|
       @|/AnonClass.java|89|95|Object|class|java.lang.Object|false
       Anon Class Start: AnonClass.Nested$1

--- a/src/test/resources/GenericClasses_ret.txt
+++ b/src/test/resources/GenericClasses_ret.txt
@@ -21,8 +21,8 @@ Class Start: GenericClasses
       @|/GenericClasses.java|288|292|main|method|GenericClasses|main|()V
       @|/GenericClasses.java|309|313|IFoo|class|GenericClasses.IFoo|false
       @|/GenericClasses.java|314|320|String|class|java.lang.String|false
-      @|/GenericClasses.java|338|344|String|class|java.lang.String|false
       @|/GenericClasses.java|333|337|IFoo|class|GenericClasses.IFoo|false
+      @|/GenericClasses.java|338|344|String|class|java.lang.String|false
       Anon Class Start: GenericClasses$1
          Method Start: bar(Ljava/lang/String;)Ljava/lang/String;
             @|/GenericClasses.java|395|398|arg|param|GenericClasses$1|bar|(Ljava/lang/String;)Ljava/lang/String;|arg|0

--- a/src/test/resources/GenericClasses_ret.txt
+++ b/src/test/resources/GenericClasses_ret.txt
@@ -21,8 +21,8 @@ Class Start: GenericClasses
       @|/GenericClasses.java|288|292|main|method|GenericClasses|main|()V
       @|/GenericClasses.java|309|313|IFoo|class|GenericClasses.IFoo|false
       @|/GenericClasses.java|314|320|String|class|java.lang.String|false
-      @|/GenericClasses.java|333|337|IFoo|class|GenericClasses.IFoo|false
       @|/GenericClasses.java|338|344|String|class|java.lang.String|false
+      @|/GenericClasses.java|333|337|IFoo|class|GenericClasses.IFoo|false
       Anon Class Start: GenericClasses$1
          Method Start: bar(Ljava/lang/String;)Ljava/lang/String;
             @|/GenericClasses.java|395|398|arg|param|GenericClasses$1|bar|(Ljava/lang/String;)Ljava/lang/String;|arg|0

--- a/src/test/resources/InnerClass_ret.txt
+++ b/src/test/resources/InnerClass_ret.txt
@@ -8,7 +8,6 @@ Class Start: InnerClass
       Class Start: InnerClass.Inner.Nested
          @|/InnerClass.java|92|98|Nested|class|InnerClass.Inner.Nested|false
          @|/InnerClass.java|129|135|String|class|java.lang.String|false
-         @|/InnerClass.java|129|135|String|class|java.lang.String|false
          @|/InnerClass.java|136|141|value|field|InnerClass.Inner.Nested|value|
          Method Start: getValue()Ljava/lang/String;
             @|/InnerClass.java|169|175|String|class|java.lang.String|false
@@ -16,7 +15,6 @@ Class Start: InnerClass
             @|/InnerClass.java|224|229|value|field|InnerClass.Inner.Nested|value
          Method End: getValue()Ljava/lang/String;
       Class End  : InnerClass.Inner.Nested
-      @|/InnerClass.java|272|278|String|class|java.lang.String|false
       @|/InnerClass.java|272|278|String|class|java.lang.String|false
       @|/InnerClass.java|279|284|value|field|InnerClass.Inner|value|
       Method Start: getValue()Ljava/lang/String;

--- a/src/test/resources/Lambda_ret.txt
+++ b/src/test/resources/Lambda_ret.txt
@@ -4,7 +4,6 @@ startProcessing "/Lambda.java" md5: 4c05901959835b10dc5618de02e3cd87
 Class Start: Lambda
    @|/Lambda.java|13|19|Lambda|class|Lambda|false
    @|/Lambda.java|40|48|Runnable|class|java.lang.Runnable|false
-   @|/Lambda.java|40|48|Runnable|class|java.lang.Runnable|false
    @|/Lambda.java|49|59|workerTask|field|Lambda|workerTask|
    @|/Lambda.java|159|164|Error|class|java.lang.Error|false
    @|/Lambda.java|301|310|Throwable|class|java.lang.Throwable|false

--- a/src/test/resources/LocalClass_ret.txt
+++ b/src/test/resources/LocalClass_ret.txt
@@ -1,62 +1,62 @@
 Symbol range map extraction starting
 Processing 1 files
-startProcessing "/LocalClass.java" md5: 006e9b91a86d02e130fed5933858a8b5
+startProcessing "/LocalClass.java" md5: b16cc963b787387f46824bf70a5ed60e
 Class Start: LocalClass
    @|/LocalClass.java|13|23|LocalClass|class|LocalClass|false
    Class Start: LocalClass.Nested
-      @|/LocalClass.java|45|51|Nested|class|LocalClass.Nested|false
+      @|/LocalClass.java|43|49|Nested|class|LocalClass.Nested|false
       Method Start: test()V
-         @|/LocalClass.java|81|85|test|method|LocalClass.Nested|test|()V
+         @|/LocalClass.java|77|81|test|method|LocalClass.Nested|test|()V
          Class Start: LocalClass.Nested$1Local
-            @|/LocalClass.java|164|170|String|class|java.lang.String|false
-            @|/LocalClass.java|164|170|String|class|java.lang.String|false
-            @|/LocalClass.java|171|176|value|field|LocalClass.Nested$1Local|value|
+            @|/LocalClass.java|156|162|String|class|java.lang.String|false
+            @|/LocalClass.java|156|162|String|class|java.lang.String|false
+            @|/LocalClass.java|163|168|value|field|LocalClass.Nested$1Local|value|
             Method Start: getValue()Ljava/lang/String;
-               @|/LocalClass.java|210|216|String|class|java.lang.String|false
-               @|/LocalClass.java|217|225|getValue|method|LocalClass.Nested$1Local|getValue|()Ljava/lang/String;
-               @|/LocalClass.java|275|280|value|field|LocalClass.Nested$1Local|value
+               @|/LocalClass.java|200|206|String|class|java.lang.String|false
+               @|/LocalClass.java|207|215|getValue|method|LocalClass.Nested$1Local|getValue|()Ljava/lang/String;
+               @|/LocalClass.java|263|268|value|field|LocalClass.Nested$1Local|value
             Method End: getValue()Ljava/lang/String;
          Class End  : LocalClass.Nested$1Local
       Method End: test()V
    Class End  : LocalClass.Nested
    Method Start: funA()V
-      @|/LocalClass.java|353|357|funA|method|LocalClass|funA|()V
+      @|/LocalClass.java|335|339|funA|method|LocalClass|funA|()V
       Class Start: LocalClass$1Local
-         @|/LocalClass.java|420|426|String|class|java.lang.String|false
-         @|/LocalClass.java|420|426|String|class|java.lang.String|false
-         @|/LocalClass.java|427|432|value|field|LocalClass$1Local|value|
+         @|/LocalClass.java|398|404|String|class|java.lang.String|false
+         @|/LocalClass.java|398|404|String|class|java.lang.String|false
+         @|/LocalClass.java|405|410|value|field|LocalClass$1Local|value|
          Method Start: getValue()Ljava/lang/String;
-            @|/LocalClass.java|462|468|String|class|java.lang.String|false
-            @|/LocalClass.java|469|477|getValue|method|LocalClass$1Local|getValue|()Ljava/lang/String;
-            @|/LocalClass.java|519|524|value|field|LocalClass$1Local|value
+            @|/LocalClass.java|438|444|String|class|java.lang.String|false
+            @|/LocalClass.java|445|453|getValue|method|LocalClass$1Local|getValue|()Ljava/lang/String;
+            @|/LocalClass.java|493|498|value|field|LocalClass$1Local|value
          Method End: getValue()Ljava/lang/String;
       Class End  : LocalClass$1Local
-      @|/LocalClass.java|575|583|getValue|method|LocalClass|getValue|()Ljava/lang/String;
+      @|/LocalClass.java|545|553|getValue|method|LocalClass|getValue|()Ljava/lang/String;
    Method End: funA()V
    Method Start: funB()V
-      @|/LocalClass.java|613|617|funB|method|LocalClass|funB|()V
+      @|/LocalClass.java|580|584|funB|method|LocalClass|funB|()V
       Class Start: LocalClass$2Local
-         @|/LocalClass.java|680|686|String|class|java.lang.String|false
-         @|/LocalClass.java|680|686|String|class|java.lang.String|false
-         @|/LocalClass.java|687|692|value|field|LocalClass$2Local|value|
+         @|/LocalClass.java|643|649|String|class|java.lang.String|false
+         @|/LocalClass.java|643|649|String|class|java.lang.String|false
+         @|/LocalClass.java|650|655|value|field|LocalClass$2Local|value|
          Method Start: getValue()Ljava/lang/String;
-            @|/LocalClass.java|722|728|String|class|java.lang.String|false
-            @|/LocalClass.java|729|737|getValue|method|LocalClass$2Local|getValue|()Ljava/lang/String;
-            @|/LocalClass.java|779|784|value|field|LocalClass$2Local|value
+            @|/LocalClass.java|683|689|String|class|java.lang.String|false
+            @|/LocalClass.java|690|698|getValue|method|LocalClass$2Local|getValue|()Ljava/lang/String;
+            @|/LocalClass.java|738|743|value|field|LocalClass$2Local|value
          Method End: getValue()Ljava/lang/String;
       Class End  : LocalClass$2Local
-      @|/LocalClass.java|835|843|getValue|method|LocalClass|getValue|()Ljava/lang/String;
+      @|/LocalClass.java|790|798|getValue|method|LocalClass|getValue|()Ljava/lang/String;
    Method End: funB()V
    Class Start: LocalClass.ITest
-      @|/LocalClass.java|878|883|ITest|class|LocalClass.ITest|false
+      @|/LocalClass.java|830|835|ITest|class|LocalClass.ITest|false
       Method Start: inFoo()V
-         @|/LocalClass.java|908|913|inFoo|method|LocalClass.ITest|inFoo|()V
+         @|/LocalClass.java|859|864|inFoo|method|LocalClass.ITest|inFoo|()V
          Class Start: LocalClass.ITest$1Target
             Method Start: test()Ljava/lang/Object;
-               @|/LocalClass.java|962|966|test|method|LocalClass.ITest$1Target|test|()Ljava/lang/Object;
+               @|/LocalClass.java|911|915|test|method|LocalClass.ITest$1Target|test|()Ljava/lang/Object;
             Method End: test()Ljava/lang/Object;
          Class End  : LocalClass.ITest$1Target
-         @|/LocalClass.java|1021|1027|String|class|java.lang.String|false
+         @|/LocalClass.java|968|974|String|class|java.lang.String|false
       Method End: inFoo()V
    Class End  : LocalClass.ITest
 Class End  : LocalClass

--- a/src/test/resources/LocalClass_ret.txt
+++ b/src/test/resources/LocalClass_ret.txt
@@ -9,7 +9,6 @@ Class Start: LocalClass
          @|/LocalClass.java|77|81|test|method|LocalClass.Nested|test|()V
          Class Start: LocalClass.Nested$1Local
             @|/LocalClass.java|156|162|String|class|java.lang.String|false
-            @|/LocalClass.java|156|162|String|class|java.lang.String|false
             @|/LocalClass.java|163|168|value|field|LocalClass.Nested$1Local|value|
             Method Start: getValue()Ljava/lang/String;
                @|/LocalClass.java|200|206|String|class|java.lang.String|false
@@ -23,7 +22,6 @@ Class Start: LocalClass
       @|/LocalClass.java|335|339|funA|method|LocalClass|funA|()V
       Class Start: LocalClass$1Local
          @|/LocalClass.java|398|404|String|class|java.lang.String|false
-         @|/LocalClass.java|398|404|String|class|java.lang.String|false
          @|/LocalClass.java|405|410|value|field|LocalClass$1Local|value|
          Method Start: getValue()Ljava/lang/String;
             @|/LocalClass.java|438|444|String|class|java.lang.String|false
@@ -36,7 +34,6 @@ Class Start: LocalClass
    Method Start: funB()V
       @|/LocalClass.java|580|584|funB|method|LocalClass|funB|()V
       Class Start: LocalClass$2Local
-         @|/LocalClass.java|643|649|String|class|java.lang.String|false
          @|/LocalClass.java|643|649|String|class|java.lang.String|false
          @|/LocalClass.java|650|655|value|field|LocalClass$2Local|value|
          Method Start: getValue()Ljava/lang/String;


### PR DESCRIPTION
 * Checks if the SimpleName type is part of a qualified type and marks it accordingly
 * Checks if new instances are qualified with an expression

Also updated the range map output for the LocalClass test to fix the test failing.