### PR TITLE
Trim substracted import line to cut off trailing line end character

### DIFF
--- a/src/main/java/net/minecraftforge/srg2source/RangeApplyMain.java
+++ b/src/main/java/net/minecraftforge/srg2source/RangeApplyMain.java
@@ -47,6 +47,7 @@ public class RangeApplyMain {
 
         OptionSpec<File> rangeArg = parser.acceptsAll(a("rm", "range", "srcRangeMap")).withRequiredArg().ofType(File.class).required();
         OptionSpec<Boolean> importArg = parser.acceptsAll(a("keepImports")).withOptionalArg().ofType(Boolean.class).defaultsTo(true);
+        OptionSpec<Boolean> overrideArg = parser.acceptsAll(a("override", "overrideOutput")).withOptionalArg().ofType(Boolean.class).defaultsTo(false);
         //OptionSpec<Boolean> annArg = parser.acceptsAll(a("annotate")).withOptionalArg().ofType(Boolean.class).defaultsTo(false);
 
         try
@@ -60,33 +61,36 @@ public class RangeApplyMain {
 
             File range = options.valueOf(rangeArg);
             Path output = options.valueOf(outArg);
+            boolean overrideOutput = options.has(overrideArg) && options.valueOf(overrideArg);
             boolean keepImports = options.has(importArg) && options.valueOf(importArg);
 
-            System.out.println("Range:   " + range);
-            System.out.println("Output:  " + output);
-            System.out.println("Imports: " + keepImports);
+            System.out.println("Range:     " + range);
+            System.out.println("Output:    " + output);
+            System.out.println("Override:  " + overrideOutput);
+            System.out.println("Imports:   " + keepImports);
 
             RangeApplierBuilder builder = new RangeApplierBuilder()
                 .range(range)
-                .output(output);
+                .output(output)
+                .outputOverride(overrideOutput);
 
             if (options.has(mappingArg))
             {
                 options.valuesOf(mappingArg).forEach(v -> {
-                    System.out.println("Map:     " + v);
+                    System.out.println("Map:       " + v);
                     builder.srg(v);
                 });
             }
 
             options.valuesOf(inputArg).forEach(v -> {
-                System.out.println("Input:   " + v);
+                System.out.println("Input:     " + v);
                 builder.input(v);
             });
 
             if (options.has(excArg))
             {
                 options.valuesOf(excArg).forEach(v -> {
-                    System.out.println("Exc:     " + v);
+                    System.out.println("Exc:       " + v);
                     builder.exc(v);
                 });
             }

--- a/src/main/java/net/minecraftforge/srg2source/RangeApplyMain.java
+++ b/src/main/java/net/minecraftforge/srg2source/RangeApplyMain.java
@@ -42,6 +42,7 @@ public class RangeApplyMain {
         OptionSpec<Path> outArg = parser.acceptsAll(a("out", "output", "outDir")).withRequiredArg().withValuesConvertedBy(PATH_CONVERTER).required();
         OptionSpec<Path> excArg = parser.acceptsAll(a("exc", "excFiles")).withRequiredArg().withValuesConvertedBy(PATH_CONVERTER);
         OptionSpec<Path> mappingArg = parser.acceptsAll(a("map", "srg", "srgFiles")).withRequiredArg().withValuesConvertedBy(PATH_CONVERTER).required();
+        OptionSpec<Path> missingArg = parser.acceptsAll(a("miss", "missing")).withRequiredArg().withValuesConvertedBy(PATH_CONVERTER);
         //TODO: Encoding arguments
 
         OptionSpec<File> rangeArg = parser.acceptsAll(a("rm", "range", "srcRangeMap")).withRequiredArg().ofType(File.class).required();
@@ -88,6 +89,13 @@ public class RangeApplyMain {
                     System.out.println("Exc:     " + v);
                     builder.exc(v);
                 });
+            }
+
+            if (options.has(missingArg))
+            {
+        	Path missing = options.valueOf(missingArg);
+        	System.out.println("Missing: " + missing);
+                builder.missing(missing);
             }
 
             if (keepImports)

--- a/src/main/java/net/minecraftforge/srg2source/api/OutputSupplier.java
+++ b/src/main/java/net/minecraftforge/srg2source/api/OutputSupplier.java
@@ -28,8 +28,9 @@ public interface OutputSupplier extends Closeable {
     /**
      * Opens an output stream to the specified resource. The resource will be created if it does not already exist. You are expected to close this stream yourself.
      * @param relPath Relative path separated with '/' and having no preceding slash.
+     * @param override Specify if output stream will override existing files in given path
      * @return An output we can stream data to
      */
     @Nullable
-    public OutputStream getOutput(String relPath);
+    public OutputStream getOutput(String relPath, boolean override);
 }

--- a/src/main/java/net/minecraftforge/srg2source/api/RangeApplierBuilder.java
+++ b/src/main/java/net/minecraftforge/srg2source/api/RangeApplierBuilder.java
@@ -42,6 +42,7 @@ public class RangeApplierBuilder {
     private PrintStream logErr = System.err;
     private List<InputSupplier> inputs = new ArrayList<>();
     private OutputSupplier output = null;
+    private boolean outputOverride = false;
     private Consumer<RangeApplier> range = null;
     private List<Consumer<RangeApplier>> srgs = new ArrayList<>();
     private List<Consumer<RangeApplier>> excs = new ArrayList<>();
@@ -69,7 +70,12 @@ public class RangeApplierBuilder {
         }
         return this;
     }
-    
+
+    public RangeApplierBuilder outputOverride(boolean value) {
+        this.outputOverride = value;
+        return this;
+    }
+
     public RangeApplierBuilder missing(Path value) {
         this.missing = value;
         return this;

--- a/src/main/java/net/minecraftforge/srg2source/api/RangeApplierBuilder.java
+++ b/src/main/java/net/minecraftforge/srg2source/api/RangeApplierBuilder.java
@@ -46,6 +46,7 @@ public class RangeApplierBuilder {
     private List<Consumer<RangeApplier>> srgs = new ArrayList<>();
     private List<Consumer<RangeApplier>> excs = new ArrayList<>();
     private boolean keepImports = false;
+    private Path missing = null;
 
     public RangeApplierBuilder logger(PrintStream value) {
         this.logStd = value;
@@ -66,6 +67,11 @@ public class RangeApplierBuilder {
         } catch (IOException e) {
             throw new IllegalArgumentException("Invalid output: " + value, e);
         }
+        return this;
+    }
+    
+    public RangeApplierBuilder missing(Path value) {
+        this.missing = value;
         return this;
     }
 
@@ -151,6 +157,7 @@ public class RangeApplierBuilder {
         excs.forEach(e -> e.accept(ret));
 
         ret.keepImports(keepImports);
+        ret.printMissing(missing);
 
         return ret;
     }

--- a/src/main/java/net/minecraftforge/srg2source/apply/RangeApplier.java
+++ b/src/main/java/net/minecraftforge/srg2source/apply/RangeApplier.java
@@ -364,6 +364,7 @@ public class RangeApplier extends ConfLogger<RangeApplier> {
                 Matcher match = IMPORT.matcher(line);
                 if (!match.matches()) {
                     error("Error: Invalid import line: " + line); //Do we want to error out?
+                    lastIndex = nextIndex + 1;
                     nextIndex = getNextIndex(data.indexOf("\n", nextIndex + 1), data.length(), nextIndex + 1);
                     continue;
                 }

--- a/src/main/java/net/minecraftforge/srg2source/apply/RangeApplier.java
+++ b/src/main/java/net/minecraftforge/srg2source/apply/RangeApplier.java
@@ -341,7 +341,7 @@ public class RangeApplier extends ConfLogger<RangeApplier> {
         int packageLine = -1;
 
         while (nextIndex > -1) {
-            String line = data.substring(lastIndex, nextIndex);
+            String line = data.substring(lastIndex, nextIndex).trim();
             int comment = line.indexOf("//");
 
             while ((comment == -1 ? line : line.substring(0, comment)).trim().isEmpty()) {
@@ -349,7 +349,7 @@ public class RangeApplier extends ConfLogger<RangeApplier> {
                 nextIndex = getNextIndex(data.indexOf("\n", lastIndex), data.length(), lastIndex);
                 if (nextIndex == -1) //EOF
                     break;
-                line = data.substring(lastIndex, nextIndex);
+                line = data.substring(lastIndex, nextIndex).trim();
                 comment = line.indexOf("//");
             }
 

--- a/src/main/java/net/minecraftforge/srg2source/apply/RangeApplier.java
+++ b/src/main/java/net/minecraftforge/srg2source/apply/RangeApplier.java
@@ -379,7 +379,8 @@ public class RangeApplier extends ConfLogger<RangeApplier> {
                         old = old.substring(0, old.length() - 2);
                         cEnd -= 2;
                     } else {
-                        error("Error: Invalid import line: Static Method Imports not supported: " + line); //Do we want to error out?
+                        error("Error: Static imports not supported: " + line); //Do we want to error out?
+                        lastIndex = nextIndex + 1;
                         nextIndex = getNextIndex(data.indexOf("\n", nextIndex + 1), data.length(), nextIndex + 1);
                         continue;
                     }

--- a/src/main/java/net/minecraftforge/srg2source/apply/RangeApplier.java
+++ b/src/main/java/net/minecraftforge/srg2source/apply/RangeApplier.java
@@ -68,6 +68,7 @@ public class RangeApplier extends ConfLogger<RangeApplier> {
     private boolean keepImports = false; // Keep imports that are not referenced anywhere in code.
     private InputSupplier input = null;
     private OutputSupplier output = null;
+    private boolean outputOverride = false; // Override output if exist
     private Map<String, RangeMap> range = new HashMap<>();
     private ClassMeta meta = null;
     
@@ -103,6 +104,10 @@ public class RangeApplier extends ConfLogger<RangeApplier> {
 
     public void setOutput(OutputSupplier value) {
         this.output = value;
+    }
+
+    public void overrideOutput(boolean value) {
+        this.outputOverride = value;
     }
 
     public void readRangeMap(File value) {
@@ -168,7 +173,7 @@ public class RangeApplier extends ConfLogger<RangeApplier> {
 
             // write.
             if (data != null) {
-                OutputStream outStream = output.getOutput(filePath);
+                OutputStream outStream = output.getOutput(filePath, this.outputOverride);
                 if (outStream == null)
                     throw new IllegalStateException("Could not get output stream form: " + filePath);
                 outStream.write(data.getBytes(encoding));

--- a/src/main/java/net/minecraftforge/srg2source/extract/ExtractUtil.java
+++ b/src/main/java/net/minecraftforge/srg2source/extract/ExtractUtil.java
@@ -110,7 +110,7 @@ public class ExtractUtil {
     @Nullable
     private static IMethodBinding findRoot(IMethodBinding target, @Nullable ITypeBinding type) {
         if (type == null || target.isConstructor())
-            return target;
+            return null;
 
         for (IMethodBinding mtd : type.getDeclaredMethods())
             if (target.overrides(mtd))

--- a/src/main/java/net/minecraftforge/srg2source/extract/ExtractUtil.java
+++ b/src/main/java/net/minecraftforge/srg2source/extract/ExtractUtil.java
@@ -95,12 +95,18 @@ public class ExtractUtil {
         ITypeBinding clazz = mtd.getDeclaringClass();
         if (clazz == null)
             return mtd;
-        IMethodBinding root = findRoot(mtd, clazz.getSuperclass());
-        if (root != null)
-            return root.getMethodDeclaration();
+
+        ITypeBinding sclazz = clazz.getSuperclass();
+        // If the declaring class overrides Object.class method directly, don't try to find the root in the
+        // Object superclass as mapping a method from Object.class is pointless
+        if (sclazz != null && !sclazz.getBinaryName().equals("java.lang.Object")) {
+            IMethodBinding root = findRoot(mtd, sclazz);
+            if (root != null)
+                return root.getMethodDeclaration();
+        }
 
         for (ITypeBinding intf : clazz.getInterfaces()) {
-            root = findRoot(mtd, intf);
+            IMethodBinding root = findRoot(mtd, intf);
             if (root != null)
                 return root.getMethodDeclaration();
         }

--- a/src/main/java/net/minecraftforge/srg2source/util/io/FolderSupplier.java
+++ b/src/main/java/net/minecraftforge/srg2source/util/io/FolderSupplier.java
@@ -55,7 +55,7 @@ public class FolderSupplier implements InputSupplier, OutputSupplier {
 
     @Override
     @Nullable
-    public OutputStream getOutput(String relPath) {
+    public OutputStream getOutput(String relPath, boolean override) {
         try {
             Path target = root.resolve(relPath);
             if (!Files.exists(target)) {
@@ -63,7 +63,10 @@ public class FolderSupplier implements InputSupplier, OutputSupplier {
                 if (!Files.exists(parent))
                     Files.createDirectories(parent);
             }
-            return Files.newOutputStream(target, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW);
+            if (override)
+                return Files.newOutputStream(target, StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            else
+                return Files.newOutputStream(target, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW);
         } catch (IOException e) {
             return null;
         }

--- a/src/main/java/net/minecraftforge/srg2source/util/io/ZipOutputSupplier.java
+++ b/src/main/java/net/minecraftforge/srg2source/util/io/ZipOutputSupplier.java
@@ -63,7 +63,7 @@ public class ZipOutputSupplier implements OutputSupplier {
     }
 
     @Override
-    public OutputStream getOutput(String relPath) {
+    public OutputStream getOutput(String relPath, boolean override) {
         if (tempOut != null)
             throw new IllegalStateException("You must close the previous stream before getting a new one!");
 

--- a/src/test/java/net/minecraftforge/srg2source/test/MemoryOutputSupplier.java
+++ b/src/test/java/net/minecraftforge/srg2source/test/MemoryOutputSupplier.java
@@ -36,7 +36,7 @@ public class MemoryOutputSupplier implements OutputSupplier {
     @Override public void close() throws IOException {}
 
     @Override
-    public OutputStream getOutput(final String relPath)
+    public OutputStream getOutput(final String relPath, boolean override)
     {
         return new ByteArrayOutputStream()
         {

--- a/src/test/java/net/minecraftforge/srg2source/test/SingleTests.java
+++ b/src/test/java/net/minecraftforge/srg2source/test/SingleTests.java
@@ -38,4 +38,5 @@ public class SingleTests extends SimpleTestBase {
     @Test public void testPackageInfo()    { testClass("PackageInfo"   ); }
     //@Test public void testCache()          { testClass("GenericClasses"); }
     @Test public void testWhiteSpace()     { testClass("Whitespace"    ); }
+    @Test public void testStaticImports()  { testClass("StaticImports" ); }
 }

--- a/src/test/resources/ImportSpaces/mapped.range
+++ b/src/test/resources/ImportSpaces/mapped.range
@@ -1,18 +1,18 @@
-start 1 ImportSpaces.java aa1657675a24ae5f4d082034248b9f42
-classdef 203 151 ImportSpaces
+start 1 ImportSpaces.java 2ea3cbebeaa4293730c821a8f1a3aa80
+classdef 257 151 ImportSpaces
 # Start CLASS ImportSpaces
-  class 216 12 ImportSpaces false ImportSpaces
-  methoddef 233 119 main ([Ljava/lang/String;)V
+  class 270 12 ImportSpaces false ImportSpaces
+  methoddef 287 119 main ([Ljava/lang/String;)V
   # Start METHOD main([Ljava/lang/String;)V
-    method 252 4 main ImportSpaces main ([Ljava/lang/String;)V
-    class 257 6 String false java/lang/String
-    parameter 266 4 args ImportSpaces main ([Ljava/lang/String;)V 0
-    class 278 4 List false java/util/List
-    class 283 4 Date false java/util/Date
-    class 295 11 Collections false java/util/Collections
-    method 307 9 emptyList java/util/Collections emptyList ()Ljava/util/List;
-    class 324 4 List false java/util/List
-    class 329 4 File false java/io/File
+    method 306 4 main ImportSpaces main ([Ljava/lang/String;)V
+    class 311 6 String false java/lang/String
+    parameter 320 4 args ImportSpaces main ([Ljava/lang/String;)V 0
+    class 332 4 List false java/util/List
+    class 337 4 Date false java/util/Date
+    class 349 11 Collections false java/util/Collections
+    method 361 9 emptyList java/util/Collections emptyList ()Ljava/util/List;
+    class 378 4 List false java/util/List
+    class 383 4 File false java/io/File
   # End METHOD
 # End CLASS
 end

--- a/src/test/resources/ImportSpaces/mapped/ImportSpaces.txt
+++ b/src/test/resources/ImportSpaces/mapped/ImportSpaces.txt
@@ -7,6 +7,8 @@ import java.util.Date; //And a comment on the end
 
 import java.io.*; //Test Wildcards
 
+import java.util.Map ; // import matcher fails there
+
 public class ImportSpaces {
   public static void main(String[] args) {
     List<Date> tmp = Collections.emptyList();

--- a/src/test/resources/ImportSpaces/original.range
+++ b/src/test/resources/ImportSpaces/original.range
@@ -1,18 +1,18 @@
-start 1 ImportSpaces.java aa1657675a24ae5f4d082034248b9f42
-classdef 203 151 ImportSpaces
+start 1 ImportSpaces.java 2ea3cbebeaa4293730c821a8f1a3aa80
+classdef 257 151 ImportSpaces
 # Start CLASS ImportSpaces
-  class 216 12 ImportSpaces false ImportSpaces
-  methoddef 233 119 main ([Ljava/lang/String;)V
+  class 270 12 ImportSpaces false ImportSpaces
+  methoddef 287 119 main ([Ljava/lang/String;)V
   # Start METHOD main([Ljava/lang/String;)V
-    method 252 4 main ImportSpaces main ([Ljava/lang/String;)V
-    class 257 6 String false java/lang/String
-    parameter 266 4 args ImportSpaces main ([Ljava/lang/String;)V 0
-    class 278 4 List false java/util/List
-    class 283 4 Date false java/util/Date
-    class 295 11 Collections false java/util/Collections
-    method 307 9 emptyList java/util/Collections emptyList ()Ljava/util/List;
-    class 324 4 List false java/util/List
-    class 329 4 File false java/io/File
+    method 306 4 main ImportSpaces main ([Ljava/lang/String;)V
+    class 311 6 String false java/lang/String
+    parameter 320 4 args ImportSpaces main ([Ljava/lang/String;)V 0
+    class 332 4 List false java/util/List
+    class 337 4 Date false java/util/Date
+    class 349 11 Collections false java/util/Collections
+    method 361 9 emptyList java/util/Collections emptyList ()Ljava/util/List;
+    class 378 4 List false java/util/List
+    class 383 4 File false java/io/File
   # End METHOD
 # End CLASS
 end

--- a/src/test/resources/ImportSpaces/original/ImportSpaces.txt
+++ b/src/test/resources/ImportSpaces/original/ImportSpaces.txt
@@ -7,6 +7,8 @@ import java.util.Date; //And a comment on the end
 
 import java.io.*; //Test Wildcards
 
+import java.util.Map ; // import matcher fails there
+
 public class ImportSpaces {
   public static void main(String[] args) {
     List<Date> tmp = Collections.emptyList();

--- a/src/test/resources/NestedGenerics/original.range
+++ b/src/test/resources/NestedGenerics/original.range
@@ -1,27 +1,27 @@
-start 1 Test.java ca10928048abf6b283e8a5320fa3dd0f
-classdef 102 194 Test
+start 1 Test.java 54514bf85b42bb005dfc2db581502b75
+classdef 97 189 Test
 # Start CLASS Test
-  class 115 4 Test false Test
-  methoddef 124 169 main ([Ljava/lang/String;)V
+  class 110 4 Test false Test
+  methoddef 118 166 main ([Ljava/lang/String;)V
   # Start METHOD main([Ljava/lang/String;)V
-    method 143 4 main Test main ([Ljava/lang/String;)V
-    class 148 6 String false java/lang/String
-    parameter 157 4 args Test main ([Ljava/lang/String;)V 0
-    class 168 3 Map false java/util/Map
-    class 172 4 Test false Test
-    class 178 3 Set false java/util/Set
-    class 182 6 String false java/lang/String
-    class 201 7 HashMap false java/util/HashMap
-    method 221 15 computeIfAbsent java/util/Map computeIfAbsent (Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;
-    class 241 4 Test false Test
-    parameter 249 1 k Test lambda$0 (LTest;)Ljava/util/Set; 0
-    methoddef 249 20 lambda[apply] (LTest;)Ljava/util/Set;
+    method 137 4 main Test main ([Ljava/lang/String;)V
+    class 142 6 String false java/lang/String
+    parameter 151 4 args Test main ([Ljava/lang/String;)V 0
+    class 161 3 Map false java/util/Map
+    class 165 4 Test false Test
+    class 171 3 Set false java/util/Set
+    class 175 6 String false java/lang/String
+    class 194 7 HashMap false java/util/HashMap
+    method 213 15 computeIfAbsent java/util/Map computeIfAbsent (Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;
+    class 233 4 Test false Test
+    parameter 241 1 k Test lambda$0 (LTest;)Ljava/util/Set; 0
+    methoddef 241 20 lambda[apply] (LTest;)Ljava/util/Set;
     # Start METHOD lambda[apply](LTest;)Ljava/util/Set;
-      class 258 7 HashSet false java/util/HashSet
+      class 250 7 HashSet false java/util/HashSet
     # End METHOD
-    methoddef 249 20 apply (LTest;)Ljava/util/Set;
+    methoddef 241 20 apply (LTest;)Ljava/util/Set;
     # Start METHOD apply(LTest;)Ljava/util/Set;
-      method 271 3 add java/util/Set add (Ljava/lang/Object;)Z
+      method 263 3 add java/util/Set add (Ljava/lang/Object;)Z
     # End METHOD
   # End METHOD
 # End CLASS

--- a/src/test/resources/StaticImports/mapped.range
+++ b/src/test/resources/StaticImports/mapped.range
@@ -1,0 +1,20 @@
+start 1 StaticImports.java 3730c0a11622567a5f82160d4d7b815f
+classdef 184 199 StaticImports
+# Start CLASS StaticImports
+  class 197 13 StaticImports false StaticImports
+  methoddef 215 166 main ([Ljava/lang/String;)V
+  # Start METHOD main([Ljava/lang/String;)V
+    method 234 4 main StaticImports main ([Ljava/lang/String;)V
+    class 239 6 String false java/lang/String
+    parameter 248 4 args StaticImports main ([Ljava/lang/String;)V 0
+    class 260 6 Double false java/lang/Double
+    method 274 4 sqrt java/lang/Math sqrt (D)D
+    class 287 6 Double false java/lang/Double
+    method 300 3 pow java/lang/Math pow (DD)D
+    class 314 7 Integer false java/lang/Integer
+    field 336 4 SIZE java/lang/Integer
+    class 346 7 Integer false java/lang/Integer
+    field 367 9 MAX_VALUE java/lang/Integer
+  # End METHOD
+# End CLASS
+end

--- a/src/test/resources/StaticImports/mapped/StaticImports.txt
+++ b/src/test/resources/StaticImports/mapped/StaticImports.txt
@@ -1,0 +1,13 @@
+import static java.lang.Math.sqrt;
+import static java.lang.Integer.MAX_VALUE; // static field
+import static java.lang.Math.pow; // static method
+import static java.lang.Integer.SIZE;
+
+public class StaticImports {
+  public static void main(String[] args) {
+    Double sqrt = sqrt(4);
+    Double pow = pow(2,2);
+    Integer integerSize = SIZE;
+    Integer maxInteger = MAX_VALUE;
+  }
+}

--- a/src/test/resources/StaticImports/original.range
+++ b/src/test/resources/StaticImports/original.range
@@ -1,0 +1,20 @@
+start 1 StaticImports.java 3730c0a11622567a5f82160d4d7b815f
+classdef 184 199 StaticImports
+# Start CLASS StaticImports
+  class 197 13 StaticImports false StaticImports
+  methoddef 215 166 main ([Ljava/lang/String;)V
+  # Start METHOD main([Ljava/lang/String;)V
+    method 234 4 main StaticImports main ([Ljava/lang/String;)V
+    class 239 6 String false java/lang/String
+    parameter 248 4 args StaticImports main ([Ljava/lang/String;)V 0
+    class 260 6 Double false java/lang/Double
+    method 274 4 sqrt java/lang/Math sqrt (D)D
+    class 287 6 Double false java/lang/Double
+    method 300 3 pow java/lang/Math pow (DD)D
+    class 314 7 Integer false java/lang/Integer
+    field 336 4 SIZE java/lang/Integer
+    class 346 7 Integer false java/lang/Integer
+    field 367 9 MAX_VALUE java/lang/Integer
+  # End METHOD
+# End CLASS
+end

--- a/src/test/resources/StaticImports/original/StaticImports.txt
+++ b/src/test/resources/StaticImports/original/StaticImports.txt
@@ -1,0 +1,13 @@
+import static java.lang.Math.sqrt;
+import static java.lang.Integer.MAX_VALUE; // static field
+import static java.lang.Math.pow; // static method
+import static java.lang.Integer.SIZE;
+
+public class StaticImports {
+  public static void main(String[] args) {
+    Double sqrt = sqrt(4);
+    Double pow = pow(2,2);
+    Integer integerSize = SIZE;
+    Integer maxInteger = MAX_VALUE;
+  }
+}


### PR DESCRIPTION
Helpful for Windows like files.
When import line is substracted from data to next LF character, line can contain trailing CR character if processed file is ended with CRLF. In such a situation import matcher cant match line to pattern.