### PR TITLE
Cleanup JDT patching task, use implementation configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ def gitVersion() {
 
 configurations {
     deployerJars
+    implementation.canBeResolved = true
 }
 
 dependencies {
@@ -106,24 +107,16 @@ class PatchJDTClasses extends DefaultTask {
     def RESOLVE_METHOD = 'resolve([Ljava/lang/String;[Ljava/lang/String;[Ljava/lang/String;Lorg/eclipse/jdt/core/dom/FileASTRequestor;ILjava/util/Map;I)V'
     def GET_CONTENTS = 'org/eclipse/jdt/internal/compiler/util/Util.getFileCharContent(Ljava/io/File;Ljava/lang/String;)[C'
     def HOOK_DESC_RESOLVE = '(Ljava/lang/String;Ljava/lang/String;)[C'
-    
-    @Input def targets = [] as Set
-    @Input def libraries = [] as Set
-    @OutputFile File output
-    
-    void target(String value) {
-        targets.add(value)
-    }
-    
-    void library(File value) {
-        libraries.add(value)
-    }
+
+    @Input SetProperty<String> targets = project.objects.setProperty(String.class)
+    @Input ConfigurableFileCollection libraries = project.objects.fileCollection()
+    @OutputFile RegularFileProperty output = project.objects.fileProperty()
     
     @TaskAction
     void patchClass() {
-        def toProcess = targets.collect()
-        new ZipOutputStream(new FileOutputStream(output)).withCloseable{ zout ->
-            libraries.stream().filter{ !it.isDirectory() }.each { lib ->
+        def toProcess = targets.get().collect()
+        new ZipOutputStream(new FileOutputStream(output.get().getAsFile())).withCloseable{ zout ->
+            libraries.getFiles().stream().filter{ !it.isDirectory() }.each { lib ->
                 new ZipFile(lib).withCloseable { zin -> 
                     def remove = []
                     toProcess.each{ target -> 
@@ -196,11 +189,11 @@ class PatchJDTClasses extends DefaultTask {
 }
 
 task patchJDT(type: PatchJDTClasses, dependsOn: jar) {
-    target PatchJDTClasses.COMPILATION_UNIT_RESOLVER
-    target PatchJDTClasses.RANGE_EXTRACTOR
-    library jar.archivePath
-    configurations.compile.filter{ !it.isDirectory() }.each { library it }
-    output file('build/patch_jdt.jar')
+    targets.add(PatchJDTClasses.COMPILATION_UNIT_RESOLVER)
+    targets.add(PatchJDTClasses.RANGE_EXTRACTOR)
+    libraries.from(jar.archiveFile)
+    libraries.from(configurations.compile.filter{ !it.isDirectory() })
+    output = project.layout.buildDirectory.file("patch_jdt.jar")
 }
 
 task shadowJar (type: Jar, dependsOn: patchJDT) {

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,6 @@ def gitVersion() {
 }
 
 configurations {
-    deployerJars
     implementation.canBeResolved = true
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -192,7 +192,7 @@ task patchJDT(type: PatchJDTClasses, dependsOn: jar) {
     targets.add(PatchJDTClasses.COMPILATION_UNIT_RESOLVER)
     targets.add(PatchJDTClasses.RANGE_EXTRACTOR)
     libraries.from(jar.archiveFile)
-    libraries.from(configurations.compile.filter{ !it.isDirectory() })
+    libraries.from(configurations.implementation.filter{ !it.isDirectory() })
     output = project.layout.buildDirectory.file("patch_jdt.jar")
 }
 
@@ -202,7 +202,7 @@ task shadowJar (type: Jar, dependsOn: patchJDT) {
     with jar
     
     from zipTree(patchJDT.output)
-    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    from { configurations.implementation.collect { it.isDirectory() ? it : zipTree(it) } }
     exclude 'about_files/**'
     exclude 'ant_tasks/**'
     exclude 'META-INF/versions/**'


### PR DESCRIPTION
This PR:
 * Cleans up the JDT patch task type to use Gradle `Property<T>`s and a `ConfigurableFileCollection`;
 * Moves from using the `compile` configuration to the `implementation` configuration for shadowing in dependencies;
 * Sets the `implementation` configuration as resolvable (`canBeResolved = true`), so the former change works properly; and
 * Removes the `deployerJars` configuration, which isn't used anywhere (I presume it was used in the past for a custom publishing deployer, which has been since removed).

Tested my changes via `gradlew publish`, and inspecting the published fatjar to see if the classes were patched correctly (mainly, `CompilationUnitResolver`) using IntelliJ's built-in decompiler tool.