### PR TITLE
Update JDT and fix old forge maven links

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4' // easy CLI parsing
 
     // necessary eclipse AST stuff
-    implementation 'org.eclipse.jdt:org.eclipse.jdt.core:3.14.0'
+    implementation 'org.eclipse.jdt:org.eclipse.jdt.core:3.25.0'
     
     //We use this to patch the JDT at runtime
     implementation 'cpw.mods:modlauncher:8.0.9'
@@ -66,7 +66,7 @@ dependencies {
 repositories {
     maven {
         name = "forge"
-        url = "http://files.minecraftforge.net/maven"
+        url = "https://maven.minecraftforge.net"
     }
     maven {
         name = "eclipse"

--- a/src/test/java/net/minecraftforge/srg2source/test/SimpleTestBase.java
+++ b/src/test/java/net/minecraftforge/srg2source/test/SimpleTestBase.java
@@ -56,7 +56,7 @@ import net.minecraftforge.srg2source.util.Util;
 import net.minecraftforge.srg2source.util.io.FolderSupplier;
 
 public abstract class SimpleTestBase {
-    private static final String FORGE_MAVEN = "https://files.minecraftforge.net/maven/";
+    private static final String FORGE_MAVEN = "https://maven.minecraftforge.net/";
 
     protected abstract String getPrefix();
     protected abstract List<String> getLibraries();


### PR DESCRIPTION
Updated JDT to `3.25.0` and tested to be working with `genPatches`. Updated 2 outdated forge maven links that I didn't catch last time.