### PR TITLE
Quick fix Forge maven location for jenkins.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
         maven {
             name = "forge"
-            url = "https://maven.minecraftforge.net"
+            url = "https://maven.minecraftforge.net/"
         }
         maven {
             name = "eclipse"
@@ -66,7 +66,7 @@ dependencies {
 repositories {
     maven {
         name = "forge"
-        url = "https://maven.minecraftforge.net"
+        url = "https://maven.minecraftforge.net/"
     }
     maven {
         name = "eclipse"


### PR DESCRIPTION
Jenkins' gradle setup seems to need the extra `/` in the maven location, else it leads to this mess: 
`Could not GET 'https://maven.minecraft/****.net/org/eclipse/jdt/org.eclipse.jdt.core/3.25.0/org.eclipse.jdt.core-3.25.0.pom'. Received status code 500 from server: Internal Server Error`

This may be a problem with the reposilite server, but this change fixed the build for me.