### PR TITLE
Update JDT to 3.26.0 and require Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.sf.proguard:proguard-gradle:6.1.0'
+        classpath 'com.guardsquare:proguard-gradle:7.1.0-beta5'
         classpath 'org.ow2.asm:asm:9.1'
         classpath 'org.ow2.asm:asm-tree:9.1'
         classpath 'net.minecraftforge:GradleUtils:1.+'
@@ -15,7 +15,7 @@ buildscript {
 }
 
 plugins {
-  id 'net.minecrell.licenser' version '0.4'
+  id 'org.cadixdev.licenser' version '0.6.1'
 }
 
 apply plugin: 'java'
@@ -37,8 +37,8 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.jimfs:jimfs:1.1'
 
-    implementation 'org.ow2.asm:asm:6.2.1'
-    implementation 'org.ow2.asm:asm-tree:6.2.1'
+    implementation 'org.ow2.asm:asm:9.1'
+    implementation 'org.ow2.asm:asm-tree:9.1'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4' // easy CLI parsing
 
     // necessary eclipse AST stuff
@@ -87,16 +87,16 @@ import org.objectweb.asm.*
 import org.objectweb.asm.tree.*
 
 //TODO: Eclipse complains about unused messages. Find a way to make it shut up.
-class PatchJDTClasses extends DefaultTask {
+abstract class PatchJDTClasses extends DefaultTask {
     static def COMPILATION_UNIT_RESOLVER = 'org/eclipse/jdt/core/dom/CompilationUnitResolver'
     static def RANGE_EXTRACTOR = 'net/minecraftforge/srg2source/extract/RangeExtractor'
-    def RESOLVE_METHOD = 'resolve([Ljava/lang/String;[Ljava/lang/String;[Ljava/lang/String;Lorg/eclipse/jdt/core/dom/FileASTRequestor;ILjava/util/Map;I)V'
-    def GET_CONTENTS = 'org/eclipse/jdt/internal/compiler/util/Util.getFileCharContent(Ljava/io/File;Ljava/lang/String;)[C'
-    def HOOK_DESC_RESOLVE = '(Ljava/lang/String;Ljava/lang/String;)[C'
+    static def RESOLVE_METHOD = 'resolve([Ljava/lang/String;[Ljava/lang/String;[Ljava/lang/String;Lorg/eclipse/jdt/core/dom/FileASTRequestor;ILjava/util/Map;I)V'
+    static def GET_CONTENTS = 'org/eclipse/jdt/internal/compiler/util/Util.getFileCharContent(Ljava/io/File;Ljava/lang/String;)[C'
+    static def HOOK_DESC_RESOLVE = '(Ljava/lang/String;Ljava/lang/String;)[C'
 
-    @Input SetProperty<String> targets = project.objects.setProperty(String.class)
-    @Input ConfigurableFileCollection libraries = project.objects.fileCollection()
-    @OutputFile RegularFileProperty output = project.objects.fileProperty()
+    @Input abstract SetProperty<String> getTargets()
+    @InputFiles @Classpath abstract ConfigurableFileCollection getLibraries()
+    @OutputFile abstract RegularFileProperty getOutput()
 
     @TaskAction
     void patchClass() {
@@ -227,30 +227,26 @@ task pgShrinkJar(type: proguard.gradle.ProGuardTask, dependsOn: shadowJar) {
 
     injars inputJar
     outjars obfuscatedJar
-    libraryjars([filter: '!META-INF/versions/**'], configurations.compile)
+    libraryjars([filter: '!META-INF/versions/**'], configurations.implementation)
 
-    // Automatically handle the Java version of this build.
-    if (System.getProperty('java.version').startsWith('1.')) {
-        // Before Java 9, the runtime classes were packaged in a single jar file.
-        libraryjars "${System.getProperty('java.home')}/lib/rt.jar"
-    } else {
-        // As of Java 9, the runtime classes are packaged in modular jmod files.
-        ['java.base', 'java.desktop', 'java.logging', 'jdk.unsupported', 'java.xml', 'java.management', 'java.compiler'].each {
-            libraryjars "${System.getProperty('java.home')}/jmods/${it}.jmod", jarfilter: '!**.jar', filter: '!module-info.class'
-        }
+    // Get the target JVM executable path, then go 2 files up to remove the bin\java.exe
+    def targetJvm = javaToolchains.launcherFor(java.toolchain).get().executablePath.asFile.parentFile.parentFile
+    // As of Java 9, the runtime classes are packaged in modular jmod files.
+    ['java.base', 'java.desktop', 'java.logging', 'jdk.unsupported', 'java.xml', 'java.management', 'java.compiler'].each {
+        libraryjars "$targetJvm/jmods/${it}.jmod", jarfilter: '!**.jar', filter: '!module-info.class'
     }
     configuration config
 }
 
 task shrinkJar(type: Jar, dependsOn: pgShrinkJar) {
-    classifier = 'fatjar'
+    archiveClassifier = 'fatjar'
     from zipTree(pgShrinkJar.obfuscatedJar)
     manifest.from(jar.manifest)
 }
 
 task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
-    classifier = 'sources'
+    archiveClassifier = 'sources'
 }
 
 artifacts {

--- a/build.gradle
+++ b/build.gradle
@@ -5,16 +5,12 @@ buildscript {
             name = "forge"
             url = "https://maven.minecraftforge.net/"
         }
-        maven {
-            name = "eclipse"
-            url = "https://repo.eclipse.org/content/groups/eclipse/"
-        }
     }
     dependencies {
         classpath 'net.sf.proguard:proguard-gradle:6.1.0'
-        classpath 'org.ow2.asm:asm:6.2.1'
-        classpath 'org.ow2.asm:asm-tree:6.2.1'
-        classpath 'org.eclipse.jgit:org.eclipse.jgit:5.10.0.202012080955-r'
+        classpath 'org.ow2.asm:asm:9.1'
+        classpath 'org.ow2.asm:asm-tree:9.1'
+        classpath 'net.minecraftforge:GradleUtils:1.+'
     }
 }
 
@@ -26,16 +22,12 @@ apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
-
-project.ext {
-    GIT_INFO = gitInfo(rootProject.file('.'))
-}
+apply plugin: 'net.minecraftforge.gradleutils'
 
 group = 'net.minecraftforge'
 archivesBaseName = 'srg2source'
-def branch = project.ext.GIT_INFO.branch
-version = "${project.ext.GIT_INFO.tag}.${project.ext.GIT_INFO.offset}${t -> if (branch != 'master') t << '-' + branch}"
-java.toolchain.languageVersion = JavaLanguageVersion.of(8)
+version = gradleutils.getTagOffsetBranchVersion()
+java.toolchain.languageVersion = JavaLanguageVersion.of(11)
 
 configurations {
     implementation.canBeResolved = true
@@ -50,19 +42,7 @@ dependencies {
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4' // easy CLI parsing
 
     // necessary eclipse AST stuff
-    implementation 'org.eclipse.jdt:org.eclipse.jdt.core:3.25.0'
-
-    // Because Eclipse is dumb and decided to use dynamic versions with J8 incompatibility
-    implementation('org.eclipse.platform:org.eclipse.core.resources') { version { strictly '3.14.0' } }
-    implementation('org.eclipse.platform:org.eclipse.core.runtime') { version { strictly '3.20.100' } }
-    implementation('org.eclipse.platform:org.eclipse.text') { version { strictly '3.11.0' } }
-    implementation('org.eclipse.platform:org.eclipse.core.filesystem') { version { strictly '1.7.700' } }
-    implementation('org.eclipse.platform:org.eclipse.equinox.common') { version { strictly '3.14.100' } }
-    implementation('org.eclipse.platform:org.eclipse.core.contenttype') { version { strictly '3.7.900' } }
-    implementation('org.eclipse.platform:org.eclipse.core.jobs') { version { strictly '3.10.1100' } }
-    implementation('org.eclipse.platform:org.eclipse.equinox.registry') { version { strictly '3.10.100' } }
-    implementation('org.eclipse.platform:org.eclipse.osgi') { version { strictly '3.16.200' } }
-    implementation('org.eclipse.platform:org.eclipse.core.commands') { version { strictly '3.9.800' } }
+    implementation 'org.eclipse.jdt:org.eclipse.jdt.core:3.26.0'
 
     //We use this to patch the JDT at runtime
     implementation 'cpw.mods:modlauncher:8.0.9'
@@ -332,45 +312,4 @@ publishing {
             }
         }
     }
-}
-
-def gitInfo(dir) {
-    String.metaClass.rsplit = { String del, int limit = -1 ->
-        def lst = new ArrayList()
-        def x = 0, idx
-        def tmp = delegate
-        while ((idx = tmp.lastIndexOf(del)) != -1 && (limit == -1 || x++ < limit)) {
-            lst.add(0, tmp.substring(idx + del.length(), tmp.length()))
-            tmp = tmp.substring(0, idx)
-        }
-        lst.add(0, tmp)
-        return lst
-    }
-
-    def git = null
-    try {
-        git = org.eclipse.jgit.api.Git.open(dir)
-    } catch (org.eclipse.jgit.errors.RepositoryNotFoundException e) {
-        return [
-                tag: '0.0',
-                offset: '0',
-                hash: '00000000',
-                branch: 'master',
-                commit: '0000000000000000000000',
-                abbreviatedId: '00000000'
-        ]
-    }
-    def desc = git.describe().setLong(true).setTags(true).call().rsplit('-', 2)
-    def head = git.repository.exactRef('HEAD')
-    def longBranch = head.symbolic ? head?.target?.name : null // matches Repository.getFullBranch() but returning null when on a detached HEAD
-
-    def ret = [:]
-    ret.tag = desc[0]
-    ret.offset = desc[1]
-    ret.hash = desc[2]
-    ret.branch = longBranch != null ? org.eclipse.jgit.lib.Repository.shortenRefName(longBranch) : null
-    ret.commit = org.eclipse.jgit.lib.ObjectId.toString(head.objectId)
-    ret.abbreviatedId = head.objectId.abbreviate(8).name()
-
-    return ret
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/net/minecraftforge/srg2source/api/SourceVersion.java
+++ b/src/main/java/net/minecraftforge/srg2source/api/SourceVersion.java
@@ -32,7 +32,7 @@ public enum SourceVersion {
     JAVA_13(JavaCore.VERSION_13),
     JAVA_14(JavaCore.VERSION_14),
     JAVA_15(JavaCore.VERSION_15),
-    //JAVA_16(JavaCore.VERSION_16), //TODO Wait for Eclipse JDT to update on maven central...
+    JAVA_16(JavaCore.VERSION_16),
     ;
 
     private String spec;

--- a/src/main/java/net/minecraftforge/srg2source/extract/RangeExtractor.java
+++ b/src/main/java/net/minecraftforge/srg2source/extract/RangeExtractor.java
@@ -284,7 +284,7 @@ public class RangeExtractor extends ConfLogger<RangeExtractor> {
     }
 
     private ASTParser createParser(String srcRoot) {
-        ASTParser parser = ASTParser.newParser(AST.JLS15);
+        ASTParser parser = ASTParser.newParser(AST.JLS_Latest);
         parser.setEnvironment(getLibArray(), srcRoot == null ? null : new String[] {srcRoot}, null, true);
         return setOptions(parser);
     }

--- a/src/main/java/net/minecraftforge/srg2source/extract/SymbolReferenceWalker.java
+++ b/src/main/java/net/minecraftforge/srg2source/extract/SymbolReferenceWalker.java
@@ -555,23 +555,10 @@ public class SymbolReferenceWalker {
         return false; //Do not walk children, ignore it all
     }
 
-    private boolean process(InstanceofExpression node) {
+    private boolean process(PatternInstanceofExpression node) {
         // visit children in normal left to right reading order
         acceptChild(node.getLeftOperand());
         acceptChild(node.getRightOperand());
-        SimpleName pattern = null;
-        try {
-            pattern = node.getPatternVariable();
-        } catch (UnsupportedOperationException e) {
-            // Nom: this is nasty, but the only other way to check is to use internal code. Which is also bad.
-        }
-
-        if (pattern != null) {
-            IVariableBinding bind = (IVariableBinding)pattern.resolveBinding();
-            trackLocalVariable(pattern, bind);
-            acceptChild(pattern);
-            System.currentTimeMillis();
-        }
 
         return false;
     }
@@ -730,7 +717,8 @@ public class SymbolReferenceWalker {
         @Override public boolean visit(ImportDeclaration               node) { return process(node); }
         @Override public boolean visit(InfixExpression                 node) { return true; }
         @Override public boolean visit(Initializer                     node) { return process(node); }
-        @Override public boolean visit(InstanceofExpression            node) { return process(node); }
+        @Override public boolean visit(InstanceofExpression            node) { return true; }
+        @Override public boolean visit(PatternInstanceofExpression     node) { return process(node); }
         @Override public boolean visit(IntersectionType                node) { return true; }
         @Override public boolean visit(Javadoc                         node) { return true; }
         @Override public boolean visit(LabeledStatement                node) { return process(node); }

--- a/src/main/java/net/minecraftforge/srg2source/extract/SymbolReferenceWalker.java
+++ b/src/main/java/net/minecraftforge/srg2source/extract/SymbolReferenceWalker.java
@@ -555,14 +555,6 @@ public class SymbolReferenceWalker {
         return false; //Do not walk children, ignore it all
     }
 
-    private boolean process(PatternInstanceofExpression node) {
-        // visit children in normal left to right reading order
-        acceptChild(node.getLeftOperand());
-        acceptChild(node.getRightOperand());
-
-        return false;
-    }
-
     /**
      * We output the package declaration, explicitly because we want to know that it
      * is a package declaration and not a generic simple name.
@@ -718,7 +710,7 @@ public class SymbolReferenceWalker {
         @Override public boolean visit(InfixExpression                 node) { return true; }
         @Override public boolean visit(Initializer                     node) { return process(node); }
         @Override public boolean visit(InstanceofExpression            node) { return true; }
-        @Override public boolean visit(PatternInstanceofExpression     node) { return process(node); }
+        @Override public boolean visit(PatternInstanceofExpression     node) { return true; }
         @Override public boolean visit(IntersectionType                node) { return true; }
         @Override public boolean visit(Javadoc                         node) { return true; }
         @Override public boolean visit(LabeledStatement                node) { return process(node); }

--- a/src/test/java/net/minecraftforge/srg2source/test/Java16Tests.java
+++ b/src/test/java/net/minecraftforge/srg2source/test/Java16Tests.java
@@ -26,11 +26,10 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.List;
 
-public class Java15Tests extends SimpleTestBase {
+public class Java16Tests extends SimpleTestBase {
     @Override protected String getPrefix() { return ""; }
     @Override protected List<String> getLibraries(){ return Collections.emptyList(); }
-    @Override protected RangeExtractorBuilder customize(RangeExtractorBuilder builder) { return builder.enablePreview(); };
-    @Override protected void testClass(String name) { super.testClass(name, SourceVersion.JAVA_15); }
+    @Override protected void testClass(String name) { super.testClass(name, SourceVersion.JAVA_16); }
 
     @Test public void testRecordSimple()   { testClass("RecordSimple"); }
     @Test public void testPatternMatch()   { testClass("PatternMatch"); }

--- a/src/test/resources/PackageInfo/original.range
+++ b/src/test/resources/PackageInfo/original.range
@@ -1,5 +1,5 @@
-start 1 test/package-info.java ba4c9c7968a298823b3132109eeaefdf
+start 1 test/package-info.java 2a280dbefb43cfe3a936f52dc94fb4b8
 class 1 10 Deprecated false java/lang/Deprecated
-class 13 9 Generated false javax/annotation/Generated
+class 13 9 Generated false javax/annotation/processing/Generated
 package 40 4 test
 end

--- a/src/test/resources/PackageInfo/original/test/package-info.txt
+++ b/src/test/resources/PackageInfo/original/test/package-info.txt
@@ -3,4 +3,4 @@
 package test;
 
 import java.lang.Deprecated;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;

--- a/src/test/resources/Whitespace/mapped.range
+++ b/src/test/resources/Whitespace/mapped.range
@@ -1,5 +1,5 @@
-start 1 not_test/package-info.java 682fc01d5bcf2541fc47c84b3f9fc71f
+start 1 not_test/package-info.java 69666c5b162c8c5492587fa74dd8f632
 class 1 10 Deprecated false java/lang/Deprecated
-class 13 9 Generated false javax/annotation/Generated
+class 13 9 Generated false javax/annotation/processing/Generated
 package 40 8 not_test
 end

--- a/src/test/resources/Whitespace/mapped/not_test/package-info.txt
+++ b/src/test/resources/Whitespace/mapped/not_test/package-info.txt
@@ -3,7 +3,7 @@
 package not_test;
 
 import java.lang.Deprecated;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 
 

--- a/src/test/resources/Whitespace/original.range
+++ b/src/test/resources/Whitespace/original.range
@@ -1,5 +1,5 @@
-start 1 test/package-info.java 7eb539ba06c91cfae367a10b3d495028
+start 1 test/package-info.java 47def38968ac3cd467186548e76512b7
 class 1 10 Deprecated false java/lang/Deprecated
-class 13 9 Generated false javax/annotation/Generated
+class 13 9 Generated false javax/annotation/processing/Generated
 package 40 4 test
 end

--- a/src/test/resources/Whitespace/original/test/package-info.txt
+++ b/src/test/resources/Whitespace/original/test/package-info.txt
@@ -3,7 +3,7 @@
 package test;
 
 import java.lang.Deprecated;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 
 


### PR DESCRIPTION
* Update JDT to 3.26.0 and require Java 11
* Support Java 16
* Update tests for Java 11 changes
* Update pattern matching node traversal
* Switch to GradleUtils for git info
* Update to Gradle 7.1 and ASM 9.1

This PR updates JDT to 3.26.0 and bumps Srg2Source's Java target to 11 as JDT 3.26.0 and up now requires it. The tests have been slightly updated to fix `Generated` being moved. `Java15Tests` has been renamed to `Java16Tests` and now compiles with Java 16 with preview disabled. The Gradle wrapper has been updated to 7.1, with Licenser and Proguard-Gradle also being updated to versions that support Gradle 7.1. JDT 3.26.0 moved instanceof pattern matching to its own expression, so that has been updated as well. This should be tagged as 8.0 when it is merged since it is a breaking change to the Java target.