### PR TITLE
Change RangeMap to be a hierarchy of structures with entries

### DIFF
--- a/src/main/java/net/minecraftforge/srg2source/apply/RangeApplier.java
+++ b/src/main/java/net/minecraftforge/srg2source/apply/RangeApplier.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -233,7 +234,8 @@ public class RangeApplier extends ConfLogger<RangeApplier> {
         //String newTopLevelQualifiedName = ((newTopLevelClassPackage == null ? "" : newTopLevelClassPackage + '/') + newTopLevelClassName).replace('\\', '/');
 
         // TODO: Track what code object we're in so we have more context?
-        for (RangeEntry info : rangeList.getEntries()) {
+        for (RangeEntry info : rangeList.getRoot().getEntries(true)
+                .stream().sorted(Comparator.comparing(RangeEntry::getStart)).collect(Collectors.toList())) {
             int start = info.getStart();
             int end = start + info.getLength();
             String expectedOldText = info.getText();

--- a/src/main/java/net/minecraftforge/srg2source/range/RangeMap.java
+++ b/src/main/java/net/minecraftforge/srg2source/range/RangeMap.java
@@ -42,7 +42,9 @@ import net.minecraftforge.srg2source.range.entries.StructuralEntry;
 import net.minecraftforge.srg2source.util.Util;
 
 public class RangeMap {
-    private final int SPEC = 1;
+    private static final int SPEC = 1;
+    private static final char TAB_CHAR = ' ';
+    private static final int TAB_SIZE = 2;
 
     //TODO: Support output types:
     // Directory: every range file is split into it's own file. Would allow for easier navigation/debug
@@ -106,16 +108,19 @@ public class RangeMap {
         for (int x = start; x < end; x++) {
             int depth = 0;
             for (Character ch : lines.get(x).toCharArray()) {
-                if (ch.equals(' ')) depth++; else break;
+                if (ch.equals(RangeMap.TAB_CHAR)) depth++; else break;
             }
+            depth /= RangeMap.TAB_SIZE; // depth is correlated with stack size, not indent
 
             String line = stripComment(lines.get(x)).trim();
             if (line.isEmpty())
                 continue;
 
             // Depth changed, remove last structure from stack
-            if (depth < lastDepth)
+            while (depth < lastDepth) {
                 stack.pop();
+                lastDepth--;
+            }
 
             int idx = line.indexOf(' ');
             if (idx == -1)
@@ -240,7 +245,7 @@ public class RangeMap {
         @Override
         public void accept(String line) {
             for (int x = 0; x < tabs; x++)
-                out.write("  ");
+                out.write(String.valueOf(RangeMap.TAB_CHAR).repeat(RangeMap.TAB_SIZE));
             out.print(line + '\n'); //Don't use println, as we want consistent line endings.
         }
     }

--- a/src/main/java/net/minecraftforge/srg2source/range/RangeMap.java
+++ b/src/main/java/net/minecraftforge/srg2source/range/RangeMap.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
@@ -131,9 +130,10 @@ public class RangeMap {
                 if ("meta".equals(type))
                     meta.add(MetaEntry.read(spec, line.substring(idx + 1)));
                 else if (type.endsWith("def")) { // structure
-                    StructuralEntry structure = StructuralEntry.read(spec, type.substring(0, type.length() - 3), line.substring(idx + 1));
+                    StructuralEntry parent = stack.peek();
+                    StructuralEntry structure = StructuralEntry.read(spec, type.substring(0, type.length() - 3), parent, line.substring(idx + 1));
                     // Store structure in parent structure
-                    stack.peek().addStructure(structure);
+                    parent.addStructure(structure);
                     // and push new actual processed structure on stack
                     stack.push(structure);
                 } else { // entry

--- a/src/main/java/net/minecraftforge/srg2source/range/RangeMap.java
+++ b/src/main/java/net/minecraftforge/srg2source/range/RangeMap.java
@@ -27,6 +27,7 @@ import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;

--- a/src/main/java/net/minecraftforge/srg2source/range/RangeMap.java
+++ b/src/main/java/net/minecraftforge/srg2source/range/RangeMap.java
@@ -129,20 +129,21 @@ public class RangeMap {
                 String type = line.substring(0, idx);
                 if ("meta".equals(type))
                     meta.add(MetaEntry.read(spec, line.substring(idx + 1)));
-                else if (type.endsWith("def")) { // structure
-                    StructuralEntry parent = stack.peek();
-                    StructuralEntry structure = StructuralEntry.read(spec, type.substring(0, type.length() - 3), parent, line.substring(idx + 1));
-                    // Store structure in parent structure
-                    parent.addStructure(structure);
-                    // and push new actual processed structure on stack
-                    stack.push(structure);
-                } else { // entry
-                    RangeEntry entry = RangeEntry.read(spec, type, line.substring(idx + 1));
-                    // Store entry in parent structure
-                    stack.peek().addEntry(entry);
+                else {
+                    if (type.endsWith("def")) { // structure
+                        StructuralEntry parent = stack.peek();
+                        StructuralEntry structure = StructuralEntry.read(spec, type.substring(0, type.length() - 3), parent, line.substring(idx + 1));
+                        // Store structure in parent structure
+                        parent.addStructure(structure);
+                        // and push new actual processed structure on stack
+                        stack.push(structure);
+                    } else { // entry
+                        RangeEntry entry = RangeEntry.read(spec, type, line.substring(idx + 1));
+                        // Store entry in parent structure
+                        stack.peek().addEntry(entry);
+                    }
+                    lastDepth = depth;
                 }
-
-                lastDepth = depth;
             } catch (Exception e) {
                 throw new IllegalArgumentException("Invalid RangeMap line #" + x + ": " + lines.get(x), e);
             }

--- a/src/main/java/net/minecraftforge/srg2source/range/RangeMapBuilder.java
+++ b/src/main/java/net/minecraftforge/srg2source/range/RangeMapBuilder.java
@@ -98,7 +98,7 @@ public class RangeMapBuilder extends ConfLogger<RangeMapBuilder> {
             do {
                 int lastStart = last.getStart();
                 int lastEnd = last.getStart() + last.getLength();
-                if (newEnd > lastEnd) {
+                if (newEnd > lastEnd && last.getType() != StructuralEntry.Type.RECORD) {
                     stack.pop(); // New structure is out of last range, remove last from stack
                     last = stack.peek();
                 } else

--- a/src/main/java/net/minecraftforge/srg2source/range/RangeMapBuilder.java
+++ b/src/main/java/net/minecraftforge/srg2source/range/RangeMapBuilder.java
@@ -70,6 +70,7 @@ public class RangeMapBuilder extends ConfLogger<RangeMapBuilder> {
         return new RangeMap(filename, hash, root, meta);
     }
 
+    //TODO: Make this check used again?
     private void checkOverlaps(List<? extends IRange> lst) {
         if (lst.isEmpty())
             return;
@@ -85,12 +86,15 @@ public class RangeMapBuilder extends ConfLogger<RangeMapBuilder> {
         }
     }
 
-
     private StructuralEntry getParent(IRange range) {
+        return getParent(range.getStart(), range.getLength());
+    }
+
+    private StructuralEntry getParent(int start, int length) {
         StructuralEntry last = stack.peek();
         if (last.getType() != StructuralEntry.Type.ROOT) {
-            int newStart = range.getStart();
-            int newEnd = range.getStart() + range.getLength();
+            int newStart = start;
+            int newEnd = start + length;
             do {
                 int lastStart = last.getStart();
                 int lastEnd = last.getStart() + last.getLength();
@@ -119,27 +123,27 @@ public class RangeMapBuilder extends ConfLogger<RangeMapBuilder> {
     }
 
     public void addAnnotationDeclaration(int start, int length, String name) {
-        addStructure(StructuralEntry.createAnnotation(start, length, name));
+        addStructure(StructuralEntry.createAnnotation(getParent(start, length), start, length, name));
     }
 
     public void addClassDeclaration(int start, int length, String name) {
-        addStructure(StructuralEntry.createClass(start, length, name));
+        addStructure(StructuralEntry.createClass(getParent(start, length), start, length, name));
     }
 
     public void addEnumDeclaration(int start, int length, String name) {
-        addStructure(StructuralEntry.createEnum(start, length, name));
+        addStructure(StructuralEntry.createEnum(getParent(start, length), start, length, name));
     }
 
     public void addRecordDeclaration(int start, int length, String name) {
-        addStructure(StructuralEntry.createRecord(start, length, name));
+        addStructure(StructuralEntry.createRecord(getParent(start, length), start, length, name));
     }
 
     public void addMethodDeclaration(int start, int length, String name, String desc) {
-        addStructure(StructuralEntry.createMethod(start, length, name, desc));
+        addStructure(StructuralEntry.createMethod(getParent(start, length), start, length, name, desc));
     }
 
     public void addInterfaceDeclaration(int start, int length, String name) {
-        addStructure(StructuralEntry.createInterface(start, length, name));
+        addStructure(StructuralEntry.createInterface(getParent(start, length), start, length, name));
     }
 
     // Code Elements

--- a/src/main/java/net/minecraftforge/srg2source/util/Util.java
+++ b/src/main/java/net/minecraftforge/srg2source/util/Util.java
@@ -132,4 +132,8 @@ public class Util {
             ret.add(data);
         return ret;
     }
+
+    public static String detectLineEnd(String data) {
+        return data.indexOf("\r\n" ) != -1 ? "\r\n" : "\n";
+    }
 }

--- a/src/test/resources/GenericClasses/original.range
+++ b/src/test/resources/GenericClasses/original.range
@@ -30,9 +30,9 @@ classdef 68 488 GenericClasses
     class 363 6 String false java/lang/String
     classdef 381 110 GenericClasses$1
     # Start CLASS GenericClasses$1
-      class 402 6 String false java/lang/String
       methoddef 395 86 bar (Ljava/lang/String;)Ljava/lang/String;
       # Start METHOD bar(Ljava/lang/String;)Ljava/lang/String;
+        class 402 6 String false java/lang/String
         method 409 3 bar GenericClasses$IFoo bar (Ljava/lang/Object;)Ljava/lang/Object;
         class 413 6 String false java/lang/String
         parameter 420 3 arg GenericClasses$1 bar (Ljava/lang/String;)Ljava/lang/String; 0

--- a/src/test/resources/NestedGenerics/original.range
+++ b/src/test/resources/NestedGenerics/original.range
@@ -16,9 +16,9 @@ classdef 97 189 Test
     local_variable 209 3 map Test main ([Ljava/lang/String;)V 1 Ljava/util/Map;
     method 213 15 computeIfAbsent java/util/Map computeIfAbsent (Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;
     class 233 4 Test false Test
-    parameter 241 1 k Test lambda$0 (LTest;)Ljava/util/Set; 0
     methoddef 241 20 lambda$0 (LTest;)Ljava/util/Set;
     # Start METHOD lambda$0(LTest;)Ljava/util/Set;
+      parameter 241 1 k Test lambda$0 (LTest;)Ljava/util/Set; 0
       class 250 7 HashSet false java/util/HashSet
     # End METHOD
     method 263 3 add java/util/Collection add (Ljava/lang/Object;)Z


### PR DESCRIPTION
This PR changes much of way RangeMap is built and how RangeAplier uses it to process java source file. RangeMap specification stays same.

At first, it changes data model of RangeMap:
 - RangeMap now stores elements hierarchically
 - RangeMap starts with abstract structure called ROOT
 - each structure can store other structures (children) and entries (also children) and so on
 - this hierarchy is an reflection of this what is stored in range file

Secondly, this changes RangeApplier to process RangeMap:
 - starting from ROOT structure
 - getting all childrens (structures and entries)
 - and processing them recursively
By processing it mean:
 - sorting children (as IRange) by start position to proper shifting data (important)
 - processing each child with [StructuralEntry/RangeEntry]Processor based on type:
  = if child is just RangeEntry it does same action like previously - replaces text occurence in output string
  = if child is a StructuralEntry it does processing "from start" (like starting from ROOT)

In each case all tests passes. It needed to correct some patterns (misplaced entries).

I don't know how you planned to do this kind of feature, but i think my solution will be very comfortable to expand processing functionality in future. This is good start to other features such:
 - moving class to no-package (see https://github.com/MinecraftPlus/Srg2Source/commits/package)
 - comment inserting, because we can handle whole structure such class, field, method (see https://github.com/MinecraftPlus/Srg2Source/commits/comments)
 - removing code parts like methods, fields or whole classes based on custom conditions (I'm using this for removing code parts marked with Dist annotations - see https://github.com/MinecraftPlus/Srg2Source/commits/remover)
 - and other :P
 
If something is unclear or need to correct, please give me feedback.