### PR TITLE
Fix compact constructor extraction and improve record component range calculation

### DIFF
--- a/src/main/java/net/minecraftforge/srg2source/extract/SymbolReferenceWalker.java
+++ b/src/main/java/net/minecraftforge/srg2source/extract/SymbolReferenceWalker.java
@@ -242,20 +242,15 @@ public class SymbolReferenceWalker {
         walker.acceptChildren(node.typeParameters());
 
         //walker.acceptChildren(node.recordComponents());
-        {
-            List<SingleVariableDeclaration> params = (List<SingleVariableDeclaration>)node.recordComponents();
+        List<SingleVariableDeclaration> params = (List<SingleVariableDeclaration>)node.recordComponents();
+        if (!params.isEmpty()) {
+            int start = params.get(0).getStartPosition();
 
-            int start = node.getName().getStartPosition() + node.getName().getLength();
-            for (TypeParameter n : (List<TypeParameter>)node.typeParameters()) {
-                start = n.getStartPosition() + n.getLength();
-            }
-            int end = start;
-            for (SingleVariableDeclaration n : params) {
-                end = n.getStartPosition() + n.getLength();
-            }
+            SingleVariableDeclaration last = params.get(params.size() - 1);
+            int length = (last.getStartPosition() + last.getLength()) - start;
 
             String desc = ExtractUtil.getDescriptor(params) + 'V';
-            builder.addMethodDeclaration(start, end - start, "<init>", desc);
+            builder.addMethodDeclaration(start, length, "<init>", desc);
             SymbolReferenceWalker iwalker = new SymbolReferenceWalker(walker, name, "<init>", desc);
 
             iwalker.trackParameters(params, 0);

--- a/src/test/java/net/minecraftforge/srg2source/test/Java16Tests.java
+++ b/src/test/java/net/minecraftforge/srg2source/test/Java16Tests.java
@@ -33,4 +33,5 @@ public class Java16Tests extends SimpleTestBase {
 
     @Test public void testRecordSimple()   { testClass("RecordSimple"); }
     @Test public void testPatternMatch()   { testClass("PatternMatch"); }
+    @Test public void testRecordCompact()  { testClass("RecordCompact"); }
 }

--- a/src/test/resources/RecordCompact/original.range
+++ b/src/test/resources/RecordCompact/original.range
@@ -1,0 +1,15 @@
+start 1 RecordCompact.java ea005fc13e6445d36496b1f7e6cf0882
+recorddef 0 87 RecordCompact
+# Start RECORD RecordCompact
+  class 14 13 RecordCompact false RecordCompact
+  methoddef 28 5 <init> (I)V
+  # Start METHOD <init>(I)V
+    parameter 32 1 a RecordCompact <init> (I)V 0
+  # End METHOD
+  methoddef 41 44 <init> (I)V
+  # Start METHOD <init>(I)V
+    method 48 13 RecordCompact RecordCompact <init> (I)V
+    field 72 1 a RecordCompact
+  # End METHOD
+# End RECORD
+end

--- a/src/test/resources/RecordCompact/original/RecordCompact.txt
+++ b/src/test/resources/RecordCompact/original/RecordCompact.txt
@@ -1,0 +1,5 @@
+public record RecordCompact(int a) {
+    public RecordCompact {
+        a += 1;
+    }
+}

--- a/src/test/resources/RecordSimple/original.range
+++ b/src/test/resources/RecordSimple/original.range
@@ -2,7 +2,7 @@ start 1 RecordSimple.java 3aa2d2b1c9363c614f91f80c95265687
 recorddef 0 46 RecordSimple
 # Start RECORD RecordSimple
   class 14 12 RecordSimple false RecordSimple
-  methoddef 26 80 <init> (ILjava/lang/String;)V
+  methoddef 27 15 <init> (ILjava/lang/String;)V
   # Start METHOD <init>(ILjava/lang/String;)V
     parameter 31 1 a RecordSimple <init> (ILjava/lang/String;)V 0
     class 34 6 String false java/lang/String


### PR DESCRIPTION
This treats the parameter references in compact constructors as fields since the only place in the eclipse dom they are defined are in the record declaration where they generate a different key

Changes the record component range calculation so that they don't use for loops and the range contains `int component` instead of `>(int component` if the record has at least 1 type parameter, `(int component` if the record doesn't have any type parameters, or with the original bug the entire length of the record twice plusthe length of the class before the record (and with atleast 1 type parameter with an offset of everything before the last type parameter is declared) while also making it not generate an empty method if a record contains no record components (which javac does allow)