### PR TITLE
Fix extract for record components with varargs

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -33,7 +33,7 @@ project {
 
     params {
         text("docker_jdk_version", "11", label = "Gradle version", description = "The version of the JDK to use during execution of tasks in a JDK.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
-        text("docker_gradle_version", "7.4.1", label = "Gradle version", description = "The version of Gradle to use during execution of Gradle tasks.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
+        text("docker_gradle_version", "7.4.2", label = "Gradle version", description = "The version of Gradle to use during execution of Gradle tasks.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
         text("git_main_branch", "master", label = "Git Main Branch", description = "The git main or default branch to use in VCS operations.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
         text("github_repository_name", "Srg2Source", label = "The github repository name. Used to connect to it in VCS Roots.", description = "This is the repository slug on github. So for example `Srg2Source` or `MinecraftForge`. It is interpolated into the global VCS Roots.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
         text("env.PUBLISHED_JAVA_ARTIFACT_ID", "Srg2Source", label = "Published artifact id", description = "The maven coordinate artifact id that has been published by this build. Can not be empty.", allowEmpty = false)

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -32,7 +32,7 @@ project {
     buildType(PullRequests)
 
     params {
-        text("docker_jdk_version", "11", label = "Gradle version", description = "The version of the JDK to use during execution of tasks in a JDK.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
+        text("docker_jdk_version", "17", label = "Gradle version", description = "The version of the JDK to use during execution of tasks in a JDK.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
         text("docker_gradle_version", "7.4.2", label = "Gradle version", description = "The version of Gradle to use during execution of Gradle tasks.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
         text("git_main_branch", "master", label = "Git Main Branch", description = "The git main or default branch to use in VCS operations.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
         text("github_repository_name", "Srg2Source", label = "The github repository name. Used to connect to it in VCS Roots.", description = "This is the repository slug on github. So for example `Srg2Source` or `MinecraftForge`. It is interpolated into the global VCS Roots.", display = ParameterDisplay.HIDDEN, allowEmpty = false)

--- a/build.gradle
+++ b/build.gradle
@@ -1,28 +1,22 @@
 buildscript {
     repositories {
         mavenCentral()
-        maven {
-            name = "forge"
-            url = "https://maven.minecraftforge.net/"
-        }
     }
     dependencies {
-        classpath 'com.guardsquare:proguard-gradle:7.1.1'
-        classpath 'org.ow2.asm:asm:9.2'
-        classpath 'org.ow2.asm:asm-tree:9.2'
-        classpath 'net.minecraftforge.gradleutils:GradleUtils:2.+'
+        classpath 'com.guardsquare:proguard-gradle:7.2.1'
+        classpath 'org.ow2.asm:asm:9.3'
+        classpath 'org.ow2.asm:asm-tree:9.3'
     }
 }
 
 plugins {
-  id 'org.cadixdev.licenser' version '0.6.1'
+    id 'org.cadixdev.licenser' version '0.6.1'
+    id 'java'
+    id 'idea'
+    id 'eclipse'
+    id 'maven-publish'
+    id 'net.minecraftforge.gradleutils' version '2.+'
 }
-
-apply plugin: 'java'
-apply plugin: 'idea'
-apply plugin: 'eclipse'
-apply plugin: 'maven-publish'
-apply plugin: 'net.minecraftforge.gradleutils'
 
 group = 'net.minecraftforge'
 archivesBaseName = 'srg2source'
@@ -50,12 +44,12 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.google.jimfs:jimfs:1.2'
 
-    implementation 'org.ow2.asm:asm:9.2'
-    implementation 'org.ow2.asm:asm-tree:9.2'
+    implementation 'org.ow2.asm:asm:9.3'
+    implementation 'org.ow2.asm:asm-tree:9.3'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4' // easy CLI parsing
 
     // necessary eclipse AST stuff
-    implementation 'org.eclipse.jdt:org.eclipse.jdt.core:3.28.0.v20211117-1416'
+    implementation 'org.eclipse.jdt:org.eclipse.jdt.core:3.29.0'
 
     //We use this to patch the JDT at runtime
     implementation 'cpw.mods:modlauncher:8.0.9'
@@ -64,7 +58,7 @@ dependencies {
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
 
     //Because tons of projects all parsing SRG files is annoying
-    implementation 'net.minecraftforge:srgutils:0.4.3'
+    implementation 'net.minecraftforge:srgutils:0.4.11'
 }
 
 changelog {
@@ -110,15 +104,15 @@ abstract class PatchJDTClasses extends DefaultTask {
             libraries.getFiles().stream().filter{ !it.isDirectory() }.each { lib ->
                 new ZipFile(lib).withCloseable { zin ->
                     def remove = []
-                    toProcess.each{ target -> 
+                    toProcess.each{ target ->
                         def entry = zin.getEntry(target+'.class')
                         if (entry == null)
                             return
-                        
+
                         def node = new ClassNode()
                         def reader = new ClassReader(zin.getInputStream(entry))
                         reader.accept(node, 0)
-                        
+
                         //CompilationUnitResolver allows batch compiling, the problem is it is hardcoded to read the contents from a File.
                         //So we patch this call to redirect to us, so we can get the contents from our InputSupplier
                         if (COMPILATION_UNIT_RESOLVER.equals(target)) {
@@ -159,10 +153,10 @@ abstract class PatchJDTClasses extends DefaultTask {
                             marker.instructions.add(new InsnNode(Opcodes.IRETURN))
                             logger.lifecycle('Patched: ' + node.name)
                         }
-                        
+
                         def writer = new ClassWriter(0)
                         node.accept(writer)
-                        
+
                         remove.add(target)
                         def nentry = new ZipEntry(entry.name)
                         nentry.time = 0
@@ -191,7 +185,7 @@ task shadowJar (type: Jar, dependsOn: patchJDT) {
     classifier 'shadow'
     duplicatesStrategy = 'exclude'
     with jar
-    
+
     from zipTree(patchJDT.output)
     from { configurations.implementation.collect { it.isDirectory() ? it : zipTree(it) } }
     exclude 'about_files/**'
@@ -227,7 +221,7 @@ task pgShrinkJar(type: proguard.gradle.ProGuardTask, dependsOn: shadowJar) {
     }
     inputs.file inputJar
     inputs.file config
-    
+
     outDir.mkdirs()
 
     injars inputJar
@@ -298,19 +292,6 @@ publishing {
         }
     }
     repositories {
-        maven {
-            if (System.env.MAVEN_USER) {
-                url 'https://maven.minecraftforge.net/'
-                authentication {
-                    basic(BasicAuthentication)
-                }
-                credentials {
-                    username = System.env.MAVEN_USER ?: 'not'
-                    password = System.env.MAVEN_PASSWORD ?: 'set'
-                }
-            } else {
-                url 'file://' + rootProject.file('repo').getAbsolutePath()
-            }
-        }
+        maven gradleutils.getPublishingForgeMaven()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        maven { url = 'https://maven.minecraftforge.net/' }
+    }
+}
+
 rootProject.name = 'Srg2Source'

--- a/src/main/java/net/minecraftforge/srg2source/extract/ExtractUtil.java
+++ b/src/main/java/net/minecraftforge/srg2source/extract/ExtractUtil.java
@@ -62,6 +62,8 @@ public class ExtractUtil {
         buf.append('(');
         for (SingleVariableDeclaration var : params) {
             ITypeBinding bind = var.getType().resolveBinding();
+            if (var.isVarargs())
+                bind = bind.createArrayType(1);
             buf.append(getTypeSignature(bind));
         }
         buf.append(')');

--- a/src/test/java/net/minecraftforge/srg2source/test/Java16Tests.java
+++ b/src/test/java/net/minecraftforge/srg2source/test/Java16Tests.java
@@ -19,7 +19,6 @@
 
 package net.minecraftforge.srg2source.test;
 
-import net.minecraftforge.srg2source.api.RangeExtractorBuilder;
 import net.minecraftforge.srg2source.api.SourceVersion;
 import org.junit.Test;
 
@@ -34,4 +33,5 @@ public class Java16Tests extends SimpleTestBase {
     @Test public void testRecordSimple()   { testClass("RecordSimple"); }
     @Test public void testPatternMatch()   { testClass("PatternMatch"); }
     @Test public void testRecordCompact()  { testClass("RecordCompact"); }
+    @Test public void testRecordComplex()  { testClass("RecordComplex"); }
 }

--- a/src/test/resources/RecordComplex/mapped.range
+++ b/src/test/resources/RecordComplex/mapped.range
@@ -1,0 +1,120 @@
+start 1 RecordComplex.java d253d3c7c3ab9359b7b6695a77aca042
+recorddef 142 1464 RecordComplex
+# Start RECORD RecordComplex
+  class 156 13 RecordComplex false RecordComplex
+  methoddef 170 41 <init> (ILjava/util/Map;[Ljava/lang/String;)V
+  # Start METHOD <init>(ILjava/util/Map;[Ljava/lang/String;)V
+    parameter 174 1 a RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 0
+    class 177 3 Map false java/util/Map
+    class 181 6 String false java/lang/String
+    class 189 6 String false java/lang/String
+    parameter 197 1 b RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 1
+    class 200 6 String false java/lang/String
+    parameter 210 1 c RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 2
+  # End METHOD
+  class 241 8 Supplier false java/util/function/Supplier
+  class 250 13 RecordComplex false RecordComplex
+  field 265 15 DEFAULT_FACTORY RecordComplex
+  class 283 13 RecordComplex false RecordComplex
+  field 327 7 counter RecordComplex
+  methoddef 347 111 createDefault ()LRecordComplex;
+  # Start METHOD createDefault()LRecordComplex;
+    class 361 13 RecordComplex false RecordComplex
+    method 375 13 createDefault RecordComplex createDefault ()LRecordComplex;
+    field 402 7 counter RecordComplex
+    field 429 15 DEFAULT_FACTORY RecordComplex
+    method 445 3 get java/util/function/Supplier get ()Ljava/lang/Object;
+  # End METHOD
+  methoddef 466 130 <init> (ILjava/util/Map;[Ljava/lang/String;)V
+  # Start METHOD <init>(ILjava/util/Map;[Ljava/lang/String;)V
+    method 473 13 RecordComplex RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V
+    field 502 1 a RecordComplex
+    class 534 21 IllegalStateException false java/lang/IllegalStateException
+  # End METHOD
+  methoddef 604 68 <init> ()V
+  # Start METHOD <init>()V
+    method 612 13 RecordComplex RecordComplex <init> ()V
+    class 652 7 HashMap false java/util/HashMap
+  # End METHOD
+  methoddef 680 57 a ()I
+  # Start METHOD a()I
+    method 691 1 a RecordComplex a ()I
+    field 713 1 a RecordComplex
+    field 728 1 a RecordComplex
+  # End METHOD
+  methoddef 745 118 b ()Ljava/util/Map;
+  # Start METHOD b()Ljava/util/Map;
+    class 752 3 Map false java/util/Map
+    class 756 6 String false java/lang/String
+    class 764 6 String false java/lang/String
+    method 772 1 b RecordComplex b ()Ljava/util/Map;
+    field 794 1 b RecordComplex
+    class 807 7 HashMap false java/util/HashMap
+    class 815 6 String false java/lang/String
+    class 823 6 String false java/lang/String
+    local_variable 831 7 hashMap RecordComplex b ()Ljava/util/Map; 0 Ljava/util/HashMap;
+    local_variable 841 7 hashMap RecordComplex b ()Ljava/util/Map; 0 Ljava/util/HashMap;
+  # End METHOD
+  methoddef 871 96 c ()[Ljava/lang/String;
+  # Start METHOD c()[Ljava/lang/String;
+    class 878 6 String false java/lang/String
+    method 887 1 c RecordComplex c ()[Ljava/lang/String;
+    class 912 29 UnsupportedOperationException false java/lang/UnsupportedOperationException
+  # End METHOD
+  methoddef 975 312 equals (Ljava/lang/Object;)Z
+  # Start METHOD equals(Ljava/lang/Object;)Z
+    class 976 8 Override false java/lang/Override
+    method 1005 6 equals java/lang/Object equals (Ljava/lang/Object;)Z
+    class 1012 6 Object false java/lang/Object
+    parameter 1019 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    parameter 1045 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    parameter 1087 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    method 1100 8 getClass java/lang/Object getClass ()Ljava/lang/Class;
+    parameter 1114 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    method 1116 8 getClass java/lang/Object getClass ()Ljava/lang/Class;
+    class 1164 13 RecordComplex false RecordComplex
+    local_variable 1178 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
+    class 1186 13 RecordComplex false RecordComplex
+    parameter 1201 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    field 1220 1 a RecordComplex
+    local_variable 1225 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
+    field 1230 1 a RecordComplex
+    field 1235 1 b RecordComplex
+    method 1237 6 equals java/util/Map equals (Ljava/lang/Object;)Z
+    local_variable 1244 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
+    field 1249 1 b RecordComplex
+    class 1255 6 Arrays false java/util/Arrays
+    method 1262 6 equals java/util/Arrays equals ([Ljava/lang/Object;[Ljava/lang/Object;)Z
+    field 1269 1 c RecordComplex
+    local_variable 1272 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
+    field 1277 1 c RecordComplex
+  # End METHOD
+  methoddef 1295 163 hashCode ()I
+  # Start METHOD hashCode()I
+    class 1296 8 Override false java/lang/Override
+    method 1321 8 hashCode java/lang/Object hashCode ()I
+    local_variable 1347 6 result RecordComplex hashCode ()I 0 I
+    class 1356 7 Objects false java/util/Objects
+    method 1364 4 hash java/util/Objects hash ([Ljava/lang/Object;)I
+    field 1369 1 a RecordComplex
+    field 1372 1 b RecordComplex
+    local_variable 1385 6 result RecordComplex hashCode ()I 0 I
+    local_variable 1399 6 result RecordComplex hashCode ()I 0 I
+    class 1408 6 Arrays false java/util/Arrays
+    method 1415 8 hashCode java/util/Arrays hashCode ([Ljava/lang/Object;)I
+    field 1424 1 c RecordComplex
+    local_variable 1444 6 result RecordComplex hashCode ()I 0 I
+  # End METHOD
+  methoddef 1466 137 toString ()Ljava/lang/String;
+  # Start METHOD toString()Ljava/lang/String;
+    class 1467 8 Override false java/lang/Override
+    class 1488 6 String false java/lang/String
+    method 1495 8 toString java/lang/Object toString ()Ljava/lang/String;
+    field 1545 1 a RecordComplex
+    field 1558 1 b RecordComplex
+    class 1571 6 Arrays false java/util/Arrays
+    method 1578 8 toString java/util/Arrays toString ([Ljava/lang/Object;)Ljava/lang/String;
+    field 1587 1 c RecordComplex
+  # End METHOD
+# End RECORD
+end

--- a/src/test/resources/RecordComplex/mapped.range
+++ b/src/test/resources/RecordComplex/mapped.range
@@ -1,120 +1,120 @@
-start 1 RecordComplex.java d253d3c7c3ab9359b7b6695a77aca042
-recorddef 142 1464 RecordComplex
+start 1 RecordComplex.java c94ddecab8a0f9cc0f5605f60b38adcb
+recorddef 136 1413 RecordComplex
 # Start RECORD RecordComplex
-  class 156 13 RecordComplex false RecordComplex
-  methoddef 170 41 <init> (ILjava/util/Map;[Ljava/lang/String;)V
+  class 150 13 RecordComplex false RecordComplex
+  methoddef 164 41 <init> (ILjava/util/Map;[Ljava/lang/String;)V
   # Start METHOD <init>(ILjava/util/Map;[Ljava/lang/String;)V
-    parameter 174 1 a RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 0
-    class 177 3 Map false java/util/Map
-    class 181 6 String false java/lang/String
-    class 189 6 String false java/lang/String
-    parameter 197 1 b RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 1
-    class 200 6 String false java/lang/String
-    parameter 210 1 c RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 2
+    parameter 168 1 a RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 0
+    class 171 3 Map false java/util/Map
+    class 175 6 String false java/lang/String
+    class 183 6 String false java/lang/String
+    parameter 191 1 b RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 1
+    class 194 6 String false java/lang/String
+    parameter 204 1 c RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 2
   # End METHOD
-  class 241 8 Supplier false java/util/function/Supplier
-  class 250 13 RecordComplex false RecordComplex
-  field 265 15 DEFAULT_FACTORY RecordComplex
-  class 283 13 RecordComplex false RecordComplex
-  field 327 7 counter RecordComplex
-  methoddef 347 111 createDefault ()LRecordComplex;
+  class 234 8 Supplier false java/util/function/Supplier
+  class 243 13 RecordComplex false RecordComplex
+  field 258 15 DEFAULT_FACTORY RecordComplex
+  class 276 13 RecordComplex false RecordComplex
+  field 319 7 counter RecordComplex
+  methoddef 337 108 createDefault ()LRecordComplex;
   # Start METHOD createDefault()LRecordComplex;
-    class 361 13 RecordComplex false RecordComplex
-    method 375 13 createDefault RecordComplex createDefault ()LRecordComplex;
-    field 402 7 counter RecordComplex
-    field 429 15 DEFAULT_FACTORY RecordComplex
-    method 445 3 get java/util/function/Supplier get ()Ljava/lang/Object;
+    class 351 13 RecordComplex false RecordComplex
+    method 365 13 createDefault RecordComplex createDefault ()LRecordComplex;
+    field 391 7 counter RecordComplex
+    field 417 15 DEFAULT_FACTORY RecordComplex
+    method 433 3 get java/util/function/Supplier get ()Ljava/lang/Object;
   # End METHOD
-  methoddef 466 130 <init> (ILjava/util/Map;[Ljava/lang/String;)V
+  methoddef 451 127 <init> (ILjava/util/Map;[Ljava/lang/String;)V
   # Start METHOD <init>(ILjava/util/Map;[Ljava/lang/String;)V
-    method 473 13 RecordComplex RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V
-    field 502 1 a RecordComplex
-    class 534 21 IllegalStateException false java/lang/IllegalStateException
+    method 458 13 RecordComplex RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V
+    field 486 1 a RecordComplex
+    class 517 21 IllegalStateException false java/lang/IllegalStateException
   # End METHOD
-  methoddef 604 68 <init> ()V
+  methoddef 584 66 <init> ()V
   # Start METHOD <init>()V
-    method 612 13 RecordComplex RecordComplex <init> ()V
-    class 652 7 HashMap false java/util/HashMap
+    method 592 13 RecordComplex RecordComplex <init> ()V
+    class 631 7 HashMap false java/util/HashMap
   # End METHOD
-  methoddef 680 57 a ()I
+  methoddef 656 55 a ()I
   # Start METHOD a()I
-    method 691 1 a RecordComplex a ()I
-    field 713 1 a RecordComplex
-    field 728 1 a RecordComplex
+    method 667 1 a RecordComplex a ()I
+    field 688 1 a RecordComplex
+    field 703 1 a RecordComplex
   # End METHOD
-  methoddef 745 118 b ()Ljava/util/Map;
+  methoddef 717 116 b ()Ljava/util/Map;
   # Start METHOD b()Ljava/util/Map;
-    class 752 3 Map false java/util/Map
-    class 756 6 String false java/lang/String
-    class 764 6 String false java/lang/String
-    method 772 1 b RecordComplex b ()Ljava/util/Map;
-    field 794 1 b RecordComplex
-    class 807 7 HashMap false java/util/HashMap
-    class 815 6 String false java/lang/String
-    class 823 6 String false java/lang/String
-    local_variable 831 7 hashMap RecordComplex b ()Ljava/util/Map; 0 Ljava/util/HashMap;
-    local_variable 841 7 hashMap RecordComplex b ()Ljava/util/Map; 0 Ljava/util/HashMap;
+    class 724 3 Map false java/util/Map
+    class 728 6 String false java/lang/String
+    class 736 6 String false java/lang/String
+    method 744 1 b RecordComplex b ()Ljava/util/Map;
+    field 765 1 b RecordComplex
+    class 778 7 HashMap false java/util/HashMap
+    class 786 6 String false java/lang/String
+    class 794 6 String false java/lang/String
+    local_variable 802 7 hashMap RecordComplex b ()Ljava/util/Map; 0 Ljava/util/HashMap;
+    local_variable 812 7 hashMap RecordComplex b ()Ljava/util/Map; 0 Ljava/util/HashMap;
   # End METHOD
-  methoddef 871 96 c ()[Ljava/lang/String;
+  methoddef 839 94 c ()[Ljava/lang/String;
   # Start METHOD c()[Ljava/lang/String;
-    class 878 6 String false java/lang/String
-    method 887 1 c RecordComplex c ()[Ljava/lang/String;
-    class 912 29 UnsupportedOperationException false java/lang/UnsupportedOperationException
+    class 846 6 String false java/lang/String
+    method 855 1 c RecordComplex c ()[Ljava/lang/String;
+    class 879 29 UnsupportedOperationException false java/lang/UnsupportedOperationException
   # End METHOD
-  methoddef 975 312 equals (Ljava/lang/Object;)Z
+  methoddef 939 304 equals (Ljava/lang/Object;)Z
   # Start METHOD equals(Ljava/lang/Object;)Z
-    class 976 8 Override false java/lang/Override
-    method 1005 6 equals java/lang/Object equals (Ljava/lang/Object;)Z
-    class 1012 6 Object false java/lang/Object
-    parameter 1019 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
-    parameter 1045 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
-    parameter 1087 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
-    method 1100 8 getClass java/lang/Object getClass ()Ljava/lang/Class;
-    parameter 1114 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
-    method 1116 8 getClass java/lang/Object getClass ()Ljava/lang/Class;
-    class 1164 13 RecordComplex false RecordComplex
-    local_variable 1178 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
-    class 1186 13 RecordComplex false RecordComplex
-    parameter 1201 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
-    field 1220 1 a RecordComplex
-    local_variable 1225 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
-    field 1230 1 a RecordComplex
-    field 1235 1 b RecordComplex
-    method 1237 6 equals java/util/Map equals (Ljava/lang/Object;)Z
-    local_variable 1244 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
-    field 1249 1 b RecordComplex
-    class 1255 6 Arrays false java/util/Arrays
-    method 1262 6 equals java/util/Arrays equals ([Ljava/lang/Object;[Ljava/lang/Object;)Z
-    field 1269 1 c RecordComplex
-    local_variable 1272 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
-    field 1277 1 c RecordComplex
+    class 940 8 Override false java/lang/Override
+    method 968 6 equals java/lang/Object equals (Ljava/lang/Object;)Z
+    class 975 6 Object false java/lang/Object
+    parameter 982 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    parameter 1007 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    parameter 1047 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    method 1060 8 getClass java/lang/Object getClass ()Ljava/lang/Class;
+    parameter 1074 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    method 1076 8 getClass java/lang/Object getClass ()Ljava/lang/Class;
+    class 1122 13 RecordComplex false RecordComplex
+    local_variable 1136 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
+    class 1144 13 RecordComplex false RecordComplex
+    parameter 1159 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    field 1177 1 a RecordComplex
+    local_variable 1182 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
+    field 1187 1 a RecordComplex
+    field 1192 1 b RecordComplex
+    method 1194 6 equals java/util/Map equals (Ljava/lang/Object;)Z
+    local_variable 1201 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
+    field 1206 1 b RecordComplex
+    class 1212 6 Arrays false java/util/Arrays
+    method 1219 6 equals java/util/Arrays equals ([Ljava/lang/Object;[Ljava/lang/Object;)Z
+    field 1226 1 c RecordComplex
+    local_variable 1229 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
+    field 1234 1 c RecordComplex
   # End METHOD
-  methoddef 1295 163 hashCode ()I
+  methoddef 1249 158 hashCode ()I
   # Start METHOD hashCode()I
-    class 1296 8 Override false java/lang/Override
-    method 1321 8 hashCode java/lang/Object hashCode ()I
-    local_variable 1347 6 result RecordComplex hashCode ()I 0 I
-    class 1356 7 Objects false java/util/Objects
-    method 1364 4 hash java/util/Objects hash ([Ljava/lang/Object;)I
-    field 1369 1 a RecordComplex
-    field 1372 1 b RecordComplex
-    local_variable 1385 6 result RecordComplex hashCode ()I 0 I
-    local_variable 1399 6 result RecordComplex hashCode ()I 0 I
-    class 1408 6 Arrays false java/util/Arrays
-    method 1415 8 hashCode java/util/Arrays hashCode ([Ljava/lang/Object;)I
-    field 1424 1 c RecordComplex
-    local_variable 1444 6 result RecordComplex hashCode ()I 0 I
+    class 1250 8 Override false java/lang/Override
+    method 1274 8 hashCode java/lang/Object hashCode ()I
+    local_variable 1299 6 result RecordComplex hashCode ()I 0 I
+    class 1308 7 Objects false java/util/Objects
+    method 1316 4 hash java/util/Objects hash ([Ljava/lang/Object;)I
+    field 1321 1 a RecordComplex
+    field 1324 1 b RecordComplex
+    local_variable 1336 6 result RecordComplex hashCode ()I 0 I
+    local_variable 1350 6 result RecordComplex hashCode ()I 0 I
+    class 1359 6 Arrays false java/util/Arrays
+    method 1366 8 hashCode java/util/Arrays hashCode ([Ljava/lang/Object;)I
+    field 1375 1 c RecordComplex
+    local_variable 1394 6 result RecordComplex hashCode ()I 0 I
   # End METHOD
-  methoddef 1466 137 toString ()Ljava/lang/String;
+  methoddef 1413 134 toString ()Ljava/lang/String;
   # Start METHOD toString()Ljava/lang/String;
-    class 1467 8 Override false java/lang/Override
-    class 1488 6 String false java/lang/String
-    method 1495 8 toString java/lang/Object toString ()Ljava/lang/String;
-    field 1545 1 a RecordComplex
-    field 1558 1 b RecordComplex
-    class 1571 6 Arrays false java/util/Arrays
-    method 1578 8 toString java/util/Arrays toString ([Ljava/lang/Object;)Ljava/lang/String;
-    field 1587 1 c RecordComplex
+    class 1414 8 Override false java/lang/Override
+    class 1434 6 String false java/lang/String
+    method 1441 8 toString java/lang/Object toString ()Ljava/lang/String;
+    field 1490 1 a RecordComplex
+    field 1503 1 b RecordComplex
+    class 1516 6 Arrays false java/util/Arrays
+    method 1523 8 toString java/util/Arrays toString ([Ljava/lang/Object;)Ljava/lang/String;
+    field 1532 1 c RecordComplex
   # End METHOD
 # End RECORD
 end

--- a/src/test/resources/RecordComplex/mapped.tsrg
+++ b/src/test/resources/RecordComplex/mapped.tsrg
@@ -1,0 +1,12 @@
+tsrg2 left right
+RecordComplex RecordComplex
+	a d
+	b e
+	c f
+	<init> (ILjava/util/Map;[Ljava/lang/String;)V <init>
+		0 a d
+		1 b e
+		2 c f
+	a ()I d
+	b ()Ljava/util/Map; e
+	c ()[Ljava/lang/String; f

--- a/src/test/resources/RecordComplex/mapped/RecordComplex.txt
+++ b/src/test/resources/RecordComplex/mapped/RecordComplex.txt
@@ -1,0 +1,58 @@
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public record RecordComplex(int a, Map<String, String> b, String... c) {
+    private static final Supplier<RecordComplex> DEFAULT_FACTORY = RecordComplex::new;
+    private static int counter = 5;
+
+    public static RecordComplex createDefault() {
+        counter++;
+        return DEFAULT_FACTORY.get();
+    }
+
+    public RecordComplex {
+        if (a > 100)
+            throw new IllegalStateException("a cannot be greater than 100!");
+    }
+
+    private RecordComplex() {
+        this(50, new HashMap<>());
+    }
+
+    public int a() {
+        return a == 0 ? 100 : a;
+    }
+
+    public Map<String, String> b() {
+        return b instanceof HashMap<String, String> hashMap ? hashMap : null;
+    }
+
+    public String[] c() {
+        throw new UnsupportedOperationException("Can't do that!");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        RecordComplex that = (RecordComplex) o;
+        return a == that.a && b.equals(that.b) && Arrays.equals(c, that.c);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(a, b);
+        result = 31 * result + Arrays.hashCode(c);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "RecordComplex[a=" + a + ", b=" + b + ", c=" + Arrays.toString(c) + "]";
+    }
+}

--- a/src/test/resources/RecordComplex/original.range
+++ b/src/test/resources/RecordComplex/original.range
@@ -1,120 +1,120 @@
-start 1 RecordComplex.java bda7f70dd873d4b0ee0ba01feb8bf3dd
-recorddef 142 1464 RecordComplex
+start 1 RecordComplex.java 41c83216b1c7063d3184e38cbe6f2baf
+recorddef 136 1413 RecordComplex
 # Start RECORD RecordComplex
-  class 156 13 RecordComplex false RecordComplex
-  methoddef 170 41 <init> (ILjava/util/Map;[Ljava/lang/String;)V
+  class 150 13 RecordComplex false RecordComplex
+  methoddef 164 41 <init> (ILjava/util/Map;[Ljava/lang/String;)V
   # Start METHOD <init>(ILjava/util/Map;[Ljava/lang/String;)V
-    parameter 174 1 d RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 0
-    class 177 3 Map false java/util/Map
-    class 181 6 String false java/lang/String
-    class 189 6 String false java/lang/String
-    parameter 197 1 e RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 1
-    class 200 6 String false java/lang/String
-    parameter 210 1 f RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 2
+    parameter 168 1 d RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 0
+    class 171 3 Map false java/util/Map
+    class 175 6 String false java/lang/String
+    class 183 6 String false java/lang/String
+    parameter 191 1 e RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 1
+    class 194 6 String false java/lang/String
+    parameter 204 1 f RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 2
   # End METHOD
-  class 241 8 Supplier false java/util/function/Supplier
-  class 250 13 RecordComplex false RecordComplex
-  field 265 15 DEFAULT_FACTORY RecordComplex
-  class 283 13 RecordComplex false RecordComplex
-  field 327 7 counter RecordComplex
-  methoddef 347 111 createDefault ()LRecordComplex;
+  class 234 8 Supplier false java/util/function/Supplier
+  class 243 13 RecordComplex false RecordComplex
+  field 258 15 DEFAULT_FACTORY RecordComplex
+  class 276 13 RecordComplex false RecordComplex
+  field 319 7 counter RecordComplex
+  methoddef 337 108 createDefault ()LRecordComplex;
   # Start METHOD createDefault()LRecordComplex;
-    class 361 13 RecordComplex false RecordComplex
-    method 375 13 createDefault RecordComplex createDefault ()LRecordComplex;
-    field 402 7 counter RecordComplex
-    field 429 15 DEFAULT_FACTORY RecordComplex
-    method 445 3 get java/util/function/Supplier get ()Ljava/lang/Object;
+    class 351 13 RecordComplex false RecordComplex
+    method 365 13 createDefault RecordComplex createDefault ()LRecordComplex;
+    field 391 7 counter RecordComplex
+    field 417 15 DEFAULT_FACTORY RecordComplex
+    method 433 3 get java/util/function/Supplier get ()Ljava/lang/Object;
   # End METHOD
-  methoddef 466 130 <init> (ILjava/util/Map;[Ljava/lang/String;)V
+  methoddef 451 127 <init> (ILjava/util/Map;[Ljava/lang/String;)V
   # Start METHOD <init>(ILjava/util/Map;[Ljava/lang/String;)V
-    method 473 13 RecordComplex RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V
-    field 502 1 d RecordComplex
-    class 534 21 IllegalStateException false java/lang/IllegalStateException
+    method 458 13 RecordComplex RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V
+    field 486 1 d RecordComplex
+    class 517 21 IllegalStateException false java/lang/IllegalStateException
   # End METHOD
-  methoddef 604 68 <init> ()V
+  methoddef 584 66 <init> ()V
   # Start METHOD <init>()V
-    method 612 13 RecordComplex RecordComplex <init> ()V
-    class 652 7 HashMap false java/util/HashMap
+    method 592 13 RecordComplex RecordComplex <init> ()V
+    class 631 7 HashMap false java/util/HashMap
   # End METHOD
-  methoddef 680 57 d ()I
+  methoddef 656 55 d ()I
   # Start METHOD d()I
-    method 691 1 d RecordComplex d ()I
-    field 713 1 d RecordComplex
-    field 728 1 d RecordComplex
+    method 667 1 d RecordComplex d ()I
+    field 688 1 d RecordComplex
+    field 703 1 d RecordComplex
   # End METHOD
-  methoddef 745 118 e ()Ljava/util/Map;
+  methoddef 717 116 e ()Ljava/util/Map;
   # Start METHOD e()Ljava/util/Map;
-    class 752 3 Map false java/util/Map
-    class 756 6 String false java/lang/String
-    class 764 6 String false java/lang/String
-    method 772 1 e RecordComplex e ()Ljava/util/Map;
-    field 794 1 e RecordComplex
-    class 807 7 HashMap false java/util/HashMap
-    class 815 6 String false java/lang/String
-    class 823 6 String false java/lang/String
-    local_variable 831 7 hashMap RecordComplex e ()Ljava/util/Map; 0 Ljava/util/HashMap;
-    local_variable 841 7 hashMap RecordComplex e ()Ljava/util/Map; 0 Ljava/util/HashMap;
+    class 724 3 Map false java/util/Map
+    class 728 6 String false java/lang/String
+    class 736 6 String false java/lang/String
+    method 744 1 e RecordComplex e ()Ljava/util/Map;
+    field 765 1 e RecordComplex
+    class 778 7 HashMap false java/util/HashMap
+    class 786 6 String false java/lang/String
+    class 794 6 String false java/lang/String
+    local_variable 802 7 hashMap RecordComplex e ()Ljava/util/Map; 0 Ljava/util/HashMap;
+    local_variable 812 7 hashMap RecordComplex e ()Ljava/util/Map; 0 Ljava/util/HashMap;
   # End METHOD
-  methoddef 871 96 f ()[Ljava/lang/String;
+  methoddef 839 94 f ()[Ljava/lang/String;
   # Start METHOD f()[Ljava/lang/String;
-    class 878 6 String false java/lang/String
-    method 887 1 f RecordComplex f ()[Ljava/lang/String;
-    class 912 29 UnsupportedOperationException false java/lang/UnsupportedOperationException
+    class 846 6 String false java/lang/String
+    method 855 1 f RecordComplex f ()[Ljava/lang/String;
+    class 879 29 UnsupportedOperationException false java/lang/UnsupportedOperationException
   # End METHOD
-  methoddef 975 312 equals (Ljava/lang/Object;)Z
+  methoddef 939 304 equals (Ljava/lang/Object;)Z
   # Start METHOD equals(Ljava/lang/Object;)Z
-    class 976 8 Override false java/lang/Override
-    method 1005 6 equals java/lang/Object equals (Ljava/lang/Object;)Z
-    class 1012 6 Object false java/lang/Object
-    parameter 1019 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
-    parameter 1045 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
-    parameter 1087 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
-    method 1100 8 getClass java/lang/Object getClass ()Ljava/lang/Class;
-    parameter 1114 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
-    method 1116 8 getClass java/lang/Object getClass ()Ljava/lang/Class;
-    class 1164 13 RecordComplex false RecordComplex
-    local_variable 1178 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
-    class 1186 13 RecordComplex false RecordComplex
-    parameter 1201 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
-    field 1220 1 d RecordComplex
-    local_variable 1225 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
-    field 1230 1 d RecordComplex
-    field 1235 1 e RecordComplex
-    method 1237 6 equals java/util/Map equals (Ljava/lang/Object;)Z
-    local_variable 1244 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
-    field 1249 1 e RecordComplex
-    class 1255 6 Arrays false java/util/Arrays
-    method 1262 6 equals java/util/Arrays equals ([Ljava/lang/Object;[Ljava/lang/Object;)Z
-    field 1269 1 f RecordComplex
-    local_variable 1272 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
-    field 1277 1 f RecordComplex
+    class 940 8 Override false java/lang/Override
+    method 968 6 equals java/lang/Object equals (Ljava/lang/Object;)Z
+    class 975 6 Object false java/lang/Object
+    parameter 982 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    parameter 1007 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    parameter 1047 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    method 1060 8 getClass java/lang/Object getClass ()Ljava/lang/Class;
+    parameter 1074 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    method 1076 8 getClass java/lang/Object getClass ()Ljava/lang/Class;
+    class 1122 13 RecordComplex false RecordComplex
+    local_variable 1136 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
+    class 1144 13 RecordComplex false RecordComplex
+    parameter 1159 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    field 1177 1 d RecordComplex
+    local_variable 1182 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
+    field 1187 1 d RecordComplex
+    field 1192 1 e RecordComplex
+    method 1194 6 equals java/util/Map equals (Ljava/lang/Object;)Z
+    local_variable 1201 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
+    field 1206 1 e RecordComplex
+    class 1212 6 Arrays false java/util/Arrays
+    method 1219 6 equals java/util/Arrays equals ([Ljava/lang/Object;[Ljava/lang/Object;)Z
+    field 1226 1 f RecordComplex
+    local_variable 1229 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
+    field 1234 1 f RecordComplex
   # End METHOD
-  methoddef 1295 163 hashCode ()I
+  methoddef 1249 158 hashCode ()I
   # Start METHOD hashCode()I
-    class 1296 8 Override false java/lang/Override
-    method 1321 8 hashCode java/lang/Object hashCode ()I
-    local_variable 1347 6 result RecordComplex hashCode ()I 0 I
-    class 1356 7 Objects false java/util/Objects
-    method 1364 4 hash java/util/Objects hash ([Ljava/lang/Object;)I
-    field 1369 1 d RecordComplex
-    field 1372 1 e RecordComplex
-    local_variable 1385 6 result RecordComplex hashCode ()I 0 I
-    local_variable 1399 6 result RecordComplex hashCode ()I 0 I
-    class 1408 6 Arrays false java/util/Arrays
-    method 1415 8 hashCode java/util/Arrays hashCode ([Ljava/lang/Object;)I
-    field 1424 1 f RecordComplex
-    local_variable 1444 6 result RecordComplex hashCode ()I 0 I
+    class 1250 8 Override false java/lang/Override
+    method 1274 8 hashCode java/lang/Object hashCode ()I
+    local_variable 1299 6 result RecordComplex hashCode ()I 0 I
+    class 1308 7 Objects false java/util/Objects
+    method 1316 4 hash java/util/Objects hash ([Ljava/lang/Object;)I
+    field 1321 1 d RecordComplex
+    field 1324 1 e RecordComplex
+    local_variable 1336 6 result RecordComplex hashCode ()I 0 I
+    local_variable 1350 6 result RecordComplex hashCode ()I 0 I
+    class 1359 6 Arrays false java/util/Arrays
+    method 1366 8 hashCode java/util/Arrays hashCode ([Ljava/lang/Object;)I
+    field 1375 1 f RecordComplex
+    local_variable 1394 6 result RecordComplex hashCode ()I 0 I
   # End METHOD
-  methoddef 1466 137 toString ()Ljava/lang/String;
+  methoddef 1413 134 toString ()Ljava/lang/String;
   # Start METHOD toString()Ljava/lang/String;
-    class 1467 8 Override false java/lang/Override
-    class 1488 6 String false java/lang/String
-    method 1495 8 toString java/lang/Object toString ()Ljava/lang/String;
-    field 1545 1 d RecordComplex
-    field 1558 1 e RecordComplex
-    class 1571 6 Arrays false java/util/Arrays
-    method 1578 8 toString java/util/Arrays toString ([Ljava/lang/Object;)Ljava/lang/String;
-    field 1587 1 f RecordComplex
+    class 1414 8 Override false java/lang/Override
+    class 1434 6 String false java/lang/String
+    method 1441 8 toString java/lang/Object toString ()Ljava/lang/String;
+    field 1490 1 d RecordComplex
+    field 1503 1 e RecordComplex
+    class 1516 6 Arrays false java/util/Arrays
+    method 1523 8 toString java/util/Arrays toString ([Ljava/lang/Object;)Ljava/lang/String;
+    field 1532 1 f RecordComplex
   # End METHOD
 # End RECORD
 end

--- a/src/test/resources/RecordComplex/original.range
+++ b/src/test/resources/RecordComplex/original.range
@@ -1,0 +1,120 @@
+start 1 RecordComplex.java bda7f70dd873d4b0ee0ba01feb8bf3dd
+recorddef 142 1464 RecordComplex
+# Start RECORD RecordComplex
+  class 156 13 RecordComplex false RecordComplex
+  methoddef 170 41 <init> (ILjava/util/Map;[Ljava/lang/String;)V
+  # Start METHOD <init>(ILjava/util/Map;[Ljava/lang/String;)V
+    parameter 174 1 d RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 0
+    class 177 3 Map false java/util/Map
+    class 181 6 String false java/lang/String
+    class 189 6 String false java/lang/String
+    parameter 197 1 e RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 1
+    class 200 6 String false java/lang/String
+    parameter 210 1 f RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 2
+  # End METHOD
+  class 241 8 Supplier false java/util/function/Supplier
+  class 250 13 RecordComplex false RecordComplex
+  field 265 15 DEFAULT_FACTORY RecordComplex
+  class 283 13 RecordComplex false RecordComplex
+  field 327 7 counter RecordComplex
+  methoddef 347 111 createDefault ()LRecordComplex;
+  # Start METHOD createDefault()LRecordComplex;
+    class 361 13 RecordComplex false RecordComplex
+    method 375 13 createDefault RecordComplex createDefault ()LRecordComplex;
+    field 402 7 counter RecordComplex
+    field 429 15 DEFAULT_FACTORY RecordComplex
+    method 445 3 get java/util/function/Supplier get ()Ljava/lang/Object;
+  # End METHOD
+  methoddef 466 130 <init> (ILjava/util/Map;[Ljava/lang/String;)V
+  # Start METHOD <init>(ILjava/util/Map;[Ljava/lang/String;)V
+    method 473 13 RecordComplex RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V
+    field 502 1 d RecordComplex
+    class 534 21 IllegalStateException false java/lang/IllegalStateException
+  # End METHOD
+  methoddef 604 68 <init> ()V
+  # Start METHOD <init>()V
+    method 612 13 RecordComplex RecordComplex <init> ()V
+    class 652 7 HashMap false java/util/HashMap
+  # End METHOD
+  methoddef 680 57 d ()I
+  # Start METHOD d()I
+    method 691 1 d RecordComplex d ()I
+    field 713 1 d RecordComplex
+    field 728 1 d RecordComplex
+  # End METHOD
+  methoddef 745 118 e ()Ljava/util/Map;
+  # Start METHOD e()Ljava/util/Map;
+    class 752 3 Map false java/util/Map
+    class 756 6 String false java/lang/String
+    class 764 6 String false java/lang/String
+    method 772 1 e RecordComplex e ()Ljava/util/Map;
+    field 794 1 e RecordComplex
+    class 807 7 HashMap false java/util/HashMap
+    class 815 6 String false java/lang/String
+    class 823 6 String false java/lang/String
+    local_variable 831 7 hashMap RecordComplex e ()Ljava/util/Map; 0 Ljava/util/HashMap;
+    local_variable 841 7 hashMap RecordComplex e ()Ljava/util/Map; 0 Ljava/util/HashMap;
+  # End METHOD
+  methoddef 871 96 f ()[Ljava/lang/String;
+  # Start METHOD f()[Ljava/lang/String;
+    class 878 6 String false java/lang/String
+    method 887 1 f RecordComplex f ()[Ljava/lang/String;
+    class 912 29 UnsupportedOperationException false java/lang/UnsupportedOperationException
+  # End METHOD
+  methoddef 975 312 equals (Ljava/lang/Object;)Z
+  # Start METHOD equals(Ljava/lang/Object;)Z
+    class 976 8 Override false java/lang/Override
+    method 1005 6 equals java/lang/Object equals (Ljava/lang/Object;)Z
+    class 1012 6 Object false java/lang/Object
+    parameter 1019 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    parameter 1045 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    parameter 1087 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    method 1100 8 getClass java/lang/Object getClass ()Ljava/lang/Class;
+    parameter 1114 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    method 1116 8 getClass java/lang/Object getClass ()Ljava/lang/Class;
+    class 1164 13 RecordComplex false RecordComplex
+    local_variable 1178 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
+    class 1186 13 RecordComplex false RecordComplex
+    parameter 1201 1 o RecordComplex equals (Ljava/lang/Object;)Z 0
+    field 1220 1 d RecordComplex
+    local_variable 1225 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
+    field 1230 1 d RecordComplex
+    field 1235 1 e RecordComplex
+    method 1237 6 equals java/util/Map equals (Ljava/lang/Object;)Z
+    local_variable 1244 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
+    field 1249 1 e RecordComplex
+    class 1255 6 Arrays false java/util/Arrays
+    method 1262 6 equals java/util/Arrays equals ([Ljava/lang/Object;[Ljava/lang/Object;)Z
+    field 1269 1 f RecordComplex
+    local_variable 1272 4 that RecordComplex equals (Ljava/lang/Object;)Z 1 LRecordComplex;
+    field 1277 1 f RecordComplex
+  # End METHOD
+  methoddef 1295 163 hashCode ()I
+  # Start METHOD hashCode()I
+    class 1296 8 Override false java/lang/Override
+    method 1321 8 hashCode java/lang/Object hashCode ()I
+    local_variable 1347 6 result RecordComplex hashCode ()I 0 I
+    class 1356 7 Objects false java/util/Objects
+    method 1364 4 hash java/util/Objects hash ([Ljava/lang/Object;)I
+    field 1369 1 d RecordComplex
+    field 1372 1 e RecordComplex
+    local_variable 1385 6 result RecordComplex hashCode ()I 0 I
+    local_variable 1399 6 result RecordComplex hashCode ()I 0 I
+    class 1408 6 Arrays false java/util/Arrays
+    method 1415 8 hashCode java/util/Arrays hashCode ([Ljava/lang/Object;)I
+    field 1424 1 f RecordComplex
+    local_variable 1444 6 result RecordComplex hashCode ()I 0 I
+  # End METHOD
+  methoddef 1466 137 toString ()Ljava/lang/String;
+  # Start METHOD toString()Ljava/lang/String;
+    class 1467 8 Override false java/lang/Override
+    class 1488 6 String false java/lang/String
+    method 1495 8 toString java/lang/Object toString ()Ljava/lang/String;
+    field 1545 1 d RecordComplex
+    field 1558 1 e RecordComplex
+    class 1571 6 Arrays false java/util/Arrays
+    method 1578 8 toString java/util/Arrays toString ([Ljava/lang/Object;)Ljava/lang/String;
+    field 1587 1 f RecordComplex
+  # End METHOD
+# End RECORD
+end

--- a/src/test/resources/RecordComplex/original/RecordComplex.txt
+++ b/src/test/resources/RecordComplex/original/RecordComplex.txt
@@ -1,0 +1,58 @@
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public record RecordComplex(int d, Map<String, String> e, String... f) {
+    private static final Supplier<RecordComplex> DEFAULT_FACTORY = RecordComplex::new;
+    private static int counter = 5;
+
+    public static RecordComplex createDefault() {
+        counter++;
+        return DEFAULT_FACTORY.get();
+    }
+
+    public RecordComplex {
+        if (d > 100)
+            throw new IllegalStateException("a cannot be greater than 100!");
+    }
+
+    private RecordComplex() {
+        this(50, new HashMap<>());
+    }
+
+    public int d() {
+        return d == 0 ? 100 : d;
+    }
+
+    public Map<String, String> e() {
+        return e instanceof HashMap<String, String> hashMap ? hashMap : null;
+    }
+
+    public String[] f() {
+        throw new UnsupportedOperationException("Can't do that!");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        RecordComplex that = (RecordComplex) o;
+        return d == that.d && e.equals(that.e) && Arrays.equals(f, that.f);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(d, e);
+        result = 31 * result + Arrays.hashCode(f);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "RecordComplex[a=" + d + ", b=" + e + ", c=" + Arrays.toString(f) + "]";
+    }
+}


### PR DESCRIPTION
Currently, record components which have a varargs type at the end are not parsed correctly by Srg2Source. Instead of being interpreted as an array, the type will be unwrapped when extracting a rangemap. This fixes that bug and allows remapping of record components that use varargs. Also, updated gradle deps and gradle was bumped to 7.4.2. Proguard-gradle requires running Gradle on J11+ now, but it shouldn't be an issue as the TC configuration is already set to run the docker container with 11.