### PR TITLE
Add test for canonical record, add apply to compact record test and make record components along with parameters in canonical constructors fields

### DIFF
--- a/src/main/java/net/minecraftforge/srg2source/extract/SymbolReferenceWalker.java
+++ b/src/main/java/net/minecraftforge/srg2source/extract/SymbolReferenceWalker.java
@@ -407,7 +407,7 @@ public class SymbolReferenceWalker {
 
             case IBinding.VARIABLE:
                 IVariableBinding var = (IVariableBinding)bind;
-                if (var.isField() || (var.isParameter() && var.getDeclaringMethod().isCompactConstructor())) { //Fields, Enum Constants, and parameters in compact constructors
+                if (var.isField() || (var.isParameter() && (var.getDeclaringMethod().isCompactConstructor() || var.getDeclaringMethod().isCanonicalConstructor()))) { //Fields, Enum Constants, and parameters in canonical or compact constructors
                     ITypeBinding declaringClass = var.isField() ? var.getDeclaringClass() : var.getDeclaringMethod().getDeclaringClass();
                     if (declaringClass != null) { // Things like array.lenth is a Field reference, but has no declaring class.
                         String owner = getInternalName(declaringClass, node);
@@ -419,8 +419,10 @@ public class SymbolReferenceWalker {
                     ParamInfo info = findParameter(var.getKey());
                     if (info == null)
                         error(node, "Illegal Argument: " + var.getKey());
-                    else
+                    else if (var.isParameter())
                         builder.addParameterReference(node.getStartPosition(), node.getLength(), node.toString(), info.owner, info.name, info.desc, info.index);
+                    else
+                        builder.addFieldReference(node.getStartPosition(), node.getLength(), node.toString(), info.owner);
                 } else {
                     /*
                      *  These are local variables, the compiler gives them unique IDs in ascending order in var.getVariableId,

--- a/src/test/java/net/minecraftforge/srg2source/test/Java16Tests.java
+++ b/src/test/java/net/minecraftforge/srg2source/test/Java16Tests.java
@@ -33,5 +33,6 @@ public class Java16Tests extends SimpleTestBase {
     @Test public void testRecordSimple()   { testClass("RecordSimple"); }
     @Test public void testPatternMatch()   { testClass("PatternMatch"); }
     @Test public void testRecordCompact()  { testClass("RecordCompact"); }
+    @Test public void testRecordCanonical() { testClass("RecordCanonical"); }
     @Test public void testRecordComplex()  { testClass("RecordComplex"); }
 }

--- a/src/test/resources/RecordCanonical/mapped.range
+++ b/src/test/resources/RecordCanonical/mapped.range
@@ -1,0 +1,27 @@
+start 1 RecordCanonical.java f06bc32b8ecab4087f4169fd9f267583
+recorddef 0 230 RecordCanonical
+# Start RECORD RecordCanonical
+  class 14 15 RecordCanonical false RecordCanonical
+  class 31 6 String false java/lang/String
+  methoddef 31 15 <init> (Ljava/lang/String;I)V
+  # Start METHOD <init>(Ljava/lang/String;I)V
+    field 38 1 b RecordCanonical
+    field 45 1 a RecordCanonical
+  # End METHOD
+  methoddef 54 174 <init> (Ljava/lang/String;I)V
+  # Start METHOD <init>(Ljava/lang/String;I)V
+    method 61 15 RecordCanonical RecordCanonical <init> (Ljava/lang/String;I)V
+    class 77 6 String false java/lang/String
+    field 84 1 b RecordCanonical
+    field 91 1 a RecordCanonical
+    field 109 1 b RecordCanonical
+    field 113 1 b RecordCanonical
+    field 128 1 a RecordCanonical
+    field 154 1 a RecordCanonical
+    field 158 1 a RecordCanonical
+    field 195 1 a RecordCanonical
+    field 199 1 b RecordCanonical
+    method 201 8 hashCode java/lang/Object hashCode ()I
+  # End METHOD
+# End RECORD
+end

--- a/src/test/resources/RecordCanonical/mapped.range
+++ b/src/test/resources/RecordCanonical/mapped.range
@@ -1,27 +1,27 @@
-start 1 RecordCanonical.java f06bc32b8ecab4087f4169fd9f267583
-recorddef 0 230 RecordCanonical
+start 1 RecordCanonical.java 8302ef9c11b966d672577a467f3ec4de
+recorddef 0 229 RecordCanonical
 # Start RECORD RecordCanonical
   class 14 15 RecordCanonical false RecordCanonical
-  class 31 6 String false java/lang/String
-  methoddef 31 15 <init> (Ljava/lang/String;I)V
+  class 30 6 String false java/lang/String
+  methoddef 30 15 <init> (Ljava/lang/String;I)V
   # Start METHOD <init>(Ljava/lang/String;I)V
-    field 38 1 b RecordCanonical
-    field 45 1 a RecordCanonical
+    field 37 1 b RecordCanonical
+    field 44 1 a RecordCanonical
   # End METHOD
-  methoddef 54 174 <init> (Ljava/lang/String;I)V
+  methoddef 53 174 <init> (Ljava/lang/String;I)V
   # Start METHOD <init>(Ljava/lang/String;I)V
-    method 61 15 RecordCanonical RecordCanonical <init> (Ljava/lang/String;I)V
-    class 77 6 String false java/lang/String
-    field 84 1 b RecordCanonical
-    field 91 1 a RecordCanonical
-    field 109 1 b RecordCanonical
-    field 113 1 b RecordCanonical
-    field 128 1 a RecordCanonical
-    field 154 1 a RecordCanonical
-    field 158 1 a RecordCanonical
-    field 195 1 a RecordCanonical
-    field 199 1 b RecordCanonical
-    method 201 8 hashCode java/lang/Object hashCode ()I
+    method 60 15 RecordCanonical RecordCanonical <init> (Ljava/lang/String;I)V
+    class 76 6 String false java/lang/String
+    field 83 1 b RecordCanonical
+    field 90 1 a RecordCanonical
+    field 108 1 b RecordCanonical
+    field 112 1 b RecordCanonical
+    field 127 1 a RecordCanonical
+    field 153 1 a RecordCanonical
+    field 157 1 a RecordCanonical
+    field 194 1 a RecordCanonical
+    field 198 1 b RecordCanonical
+    method 200 8 hashCode java/lang/Object hashCode ()I
   # End METHOD
 # End RECORD
 end

--- a/src/test/resources/RecordCanonical/mapped.tsrg
+++ b/src/test/resources/RecordCanonical/mapped.tsrg
@@ -1,0 +1,4 @@
+RecordCanonical RecordCanonical
+	b a
+	a b
+	<init> (Ljava/lang/String;I)V <init>

--- a/src/test/resources/RecordCanonical/mapped/RecordCanonical.txt
+++ b/src/test/resources/RecordCanonical/mapped/RecordCanonical.txt
@@ -1,0 +1,10 @@
+public record RecordCanonical (String b, int a) {
+    public RecordCanonical(String b, int a) {
+        this.b = b;
+        if (a > 0) {
+            this.a = a;
+        } else {
+            this.a = b.hashCode();
+        }
+    }
+}

--- a/src/test/resources/RecordCanonical/mapped/RecordCanonical.txt
+++ b/src/test/resources/RecordCanonical/mapped/RecordCanonical.txt
@@ -1,4 +1,4 @@
-public record RecordCanonical (String b, int a) {
+public record RecordCanonical(String b, int a) {
     public RecordCanonical(String b, int a) {
         this.b = b;
         if (a > 0) {

--- a/src/test/resources/RecordCanonical/original.range
+++ b/src/test/resources/RecordCanonical/original.range
@@ -1,0 +1,27 @@
+start 1 RecordCanonical.java 285c481fe172fd7d8a0c1cbf0a4fa89a
+recorddef 0 230 RecordCanonical
+# Start RECORD RecordCanonical
+  class 14 15 RecordCanonical false RecordCanonical
+  class 31 6 String false java/lang/String
+  methoddef 31 15 <init> (Ljava/lang/String;I)V
+  # Start METHOD <init>(Ljava/lang/String;I)V
+    field 38 1 a RecordCanonical
+    field 45 1 b RecordCanonical
+  # End METHOD
+  methoddef 54 174 <init> (Ljava/lang/String;I)V
+  # Start METHOD <init>(Ljava/lang/String;I)V
+    method 61 15 RecordCanonical RecordCanonical <init> (Ljava/lang/String;I)V
+    class 77 6 String false java/lang/String
+    field 84 1 a RecordCanonical
+    field 91 1 b RecordCanonical
+    field 109 1 a RecordCanonical
+    field 113 1 a RecordCanonical
+    field 128 1 b RecordCanonical
+    field 154 1 b RecordCanonical
+    field 158 1 b RecordCanonical
+    field 195 1 b RecordCanonical
+    field 199 1 a RecordCanonical
+    method 201 8 hashCode java/lang/Object hashCode ()I
+  # End METHOD
+# End RECORD
+end

--- a/src/test/resources/RecordCanonical/original.range
+++ b/src/test/resources/RecordCanonical/original.range
@@ -1,27 +1,27 @@
-start 1 RecordCanonical.java 285c481fe172fd7d8a0c1cbf0a4fa89a
-recorddef 0 230 RecordCanonical
+start 1 RecordCanonical.java 9bcc25ef22a58fb07d01aab099106703
+recorddef 0 229 RecordCanonical
 # Start RECORD RecordCanonical
   class 14 15 RecordCanonical false RecordCanonical
-  class 31 6 String false java/lang/String
-  methoddef 31 15 <init> (Ljava/lang/String;I)V
+  class 30 6 String false java/lang/String
+  methoddef 30 15 <init> (Ljava/lang/String;I)V
   # Start METHOD <init>(Ljava/lang/String;I)V
-    field 38 1 a RecordCanonical
-    field 45 1 b RecordCanonical
+    field 37 1 a RecordCanonical
+    field 44 1 b RecordCanonical
   # End METHOD
-  methoddef 54 174 <init> (Ljava/lang/String;I)V
+  methoddef 53 174 <init> (Ljava/lang/String;I)V
   # Start METHOD <init>(Ljava/lang/String;I)V
-    method 61 15 RecordCanonical RecordCanonical <init> (Ljava/lang/String;I)V
-    class 77 6 String false java/lang/String
-    field 84 1 a RecordCanonical
-    field 91 1 b RecordCanonical
-    field 109 1 a RecordCanonical
-    field 113 1 a RecordCanonical
-    field 128 1 b RecordCanonical
-    field 154 1 b RecordCanonical
-    field 158 1 b RecordCanonical
-    field 195 1 b RecordCanonical
-    field 199 1 a RecordCanonical
-    method 201 8 hashCode java/lang/Object hashCode ()I
+    method 60 15 RecordCanonical RecordCanonical <init> (Ljava/lang/String;I)V
+    class 76 6 String false java/lang/String
+    field 83 1 a RecordCanonical
+    field 90 1 b RecordCanonical
+    field 108 1 a RecordCanonical
+    field 112 1 a RecordCanonical
+    field 127 1 b RecordCanonical
+    field 153 1 b RecordCanonical
+    field 157 1 b RecordCanonical
+    field 194 1 b RecordCanonical
+    field 198 1 a RecordCanonical
+    method 200 8 hashCode java/lang/Object hashCode ()I
   # End METHOD
 # End RECORD
 end

--- a/src/test/resources/RecordCanonical/original/RecordCanonical.txt
+++ b/src/test/resources/RecordCanonical/original/RecordCanonical.txt
@@ -1,0 +1,10 @@
+public record RecordCanonical (String a, int b) {
+    public RecordCanonical(String a, int b) {
+        this.a = a;
+        if (b > 0) {
+            this.b = b;
+        } else {
+            this.b = a.hashCode();
+        }
+    }
+}

--- a/src/test/resources/RecordCanonical/original/RecordCanonical.txt
+++ b/src/test/resources/RecordCanonical/original/RecordCanonical.txt
@@ -1,4 +1,4 @@
-public record RecordCanonical (String a, int b) {
+public record RecordCanonical(String a, int b) {
     public RecordCanonical(String a, int b) {
         this.a = a;
         if (b > 0) {

--- a/src/test/resources/RecordCompact/mapped.range
+++ b/src/test/resources/RecordCompact/mapped.range
@@ -1,0 +1,15 @@
+start 1 RecordCompact.java 34140c933c2ff9dc2beb308fc60f49ab
+recorddef 0 87 RecordCompact
+# Start RECORD RecordCompact
+  class 14 13 RecordCompact false RecordCompact
+  methoddef 28 5 <init> (I)V
+  # Start METHOD <init>(I)V
+    field 32 1 b RecordCompact
+  # End METHOD
+  methoddef 41 44 <init> (I)V
+  # Start METHOD <init>(I)V
+    method 48 13 RecordCompact RecordCompact <init> (I)V
+    field 72 1 b RecordCompact
+  # End METHOD
+# End RECORD
+end

--- a/src/test/resources/RecordCompact/mapped.tsrg
+++ b/src/test/resources/RecordCompact/mapped.tsrg
@@ -1,0 +1,3 @@
+RecordCompact RecordCompact
+	b a
+	<init> (I)V <init>

--- a/src/test/resources/RecordCompact/mapped/RecordCompact.txt
+++ b/src/test/resources/RecordCompact/mapped/RecordCompact.txt
@@ -1,0 +1,5 @@
+public record RecordCompact(int b) {
+    public RecordCompact {
+        b += 1;
+    }
+}

--- a/src/test/resources/RecordCompact/original.range
+++ b/src/test/resources/RecordCompact/original.range
@@ -4,7 +4,7 @@ recorddef 0 87 RecordCompact
   class 14 13 RecordCompact false RecordCompact
   methoddef 28 5 <init> (I)V
   # Start METHOD <init>(I)V
-    parameter 32 1 a RecordCompact <init> (I)V 0
+    field 32 1 a RecordCompact
   # End METHOD
   methoddef 41 44 <init> (I)V
   # Start METHOD <init>(I)V

--- a/src/test/resources/RecordComplex/mapped.range
+++ b/src/test/resources/RecordComplex/mapped.range
@@ -4,13 +4,13 @@ recorddef 136 1413 RecordComplex
   class 150 13 RecordComplex false RecordComplex
   methoddef 164 41 <init> (ILjava/util/Map;[Ljava/lang/String;)V
   # Start METHOD <init>(ILjava/util/Map;[Ljava/lang/String;)V
-    parameter 168 1 a RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 0
+    field 168 1 a RecordComplex
     class 171 3 Map false java/util/Map
     class 175 6 String false java/lang/String
     class 183 6 String false java/lang/String
-    parameter 191 1 b RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 1
+    field 191 1 b RecordComplex
     class 194 6 String false java/lang/String
-    parameter 204 1 c RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 2
+    field 204 1 c RecordComplex
   # End METHOD
   class 234 8 Supplier false java/util/function/Supplier
   class 243 13 RecordComplex false RecordComplex

--- a/src/test/resources/RecordComplex/mapped.tsrg
+++ b/src/test/resources/RecordComplex/mapped.tsrg
@@ -3,10 +3,6 @@ RecordComplex RecordComplex
 	a d
 	b e
 	c f
-	<init> (ILjava/util/Map;[Ljava/lang/String;)V <init>
-		0 a d
-		1 b e
-		2 c f
 	a ()I d
 	b ()Ljava/util/Map; e
 	c ()[Ljava/lang/String; f

--- a/src/test/resources/RecordComplex/original.range
+++ b/src/test/resources/RecordComplex/original.range
@@ -4,13 +4,13 @@ recorddef 136 1413 RecordComplex
   class 150 13 RecordComplex false RecordComplex
   methoddef 164 41 <init> (ILjava/util/Map;[Ljava/lang/String;)V
   # Start METHOD <init>(ILjava/util/Map;[Ljava/lang/String;)V
-    parameter 168 1 d RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 0
+    field 168 1 d RecordComplex
     class 171 3 Map false java/util/Map
     class 175 6 String false java/lang/String
     class 183 6 String false java/lang/String
-    parameter 191 1 e RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 1
+    field 191 1 e RecordComplex
     class 194 6 String false java/lang/String
-    parameter 204 1 f RecordComplex <init> (ILjava/util/Map;[Ljava/lang/String;)V 2
+    field 204 1 f RecordComplex
   # End METHOD
   class 234 8 Supplier false java/util/function/Supplier
   class 243 13 RecordComplex false RecordComplex

--- a/src/test/resources/RecordSimple/mapped.range
+++ b/src/test/resources/RecordSimple/mapped.range
@@ -1,12 +1,12 @@
-start 1 RecordSimple.java 3aa2d2b1c9363c614f91f80c95265687
+start 1 RecordSimple.java 9ac473292325c5569c378efb816089db
 recorddef 0 46 RecordSimple
 # Start RECORD RecordSimple
   class 14 12 RecordSimple false RecordSimple
   methoddef 27 15 <init> (ILjava/lang/String;)V
   # Start METHOD <init>(ILjava/lang/String;)V
-    field 31 1 a RecordSimple
+    field 31 1 b RecordSimple
     class 34 6 String false java/lang/String
-    field 41 1 b RecordSimple
+    field 41 1 a RecordSimple
   # End METHOD
 # End RECORD
 end

--- a/src/test/resources/RecordSimple/mapped.tsrg
+++ b/src/test/resources/RecordSimple/mapped.tsrg
@@ -1,0 +1,4 @@
+RecordSimple RecordSimple
+	a b
+	b a
+	<init> (ILjava/lang/String;)V <init>

--- a/src/test/resources/RecordSimple/mapped/RecordSimple.txt
+++ b/src/test/resources/RecordSimple/mapped/RecordSimple.txt
@@ -1,0 +1,1 @@
+public record RecordSimple(int b, String a) {}


### PR DESCRIPTION
Adds apply test for compact constructors, extract and apply test for canonical constructors, and makes record components and canonical constructor parameters fields (since they need to be the same as the record component names) so that they can be renamed by formats that don't support parameters like slimSrg.